### PR TITLE
Use setuptools.setup console_scripts entry point.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
     - pip install flake8 pylint
 
 script:
-    - flake8 wal
-    - pylint wal
+    - flake8 pywal
+    - pylint pywal

--- a/pywal/__init__.py
+++ b/pywal/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 wal - Generate and change colorschemes on the fly.
 Created by Dylan Araps.
@@ -12,9 +11,9 @@ import shutil
 import subprocess
 import sys
 
+__version__ = "0.1.6"
 
 # Internal variables.
-VERSION = "0.1"
 COLOR_COUNT = 16
 CACHE_DIR = pathlib.Path.home() / ".cache/wal/"
 
@@ -102,7 +101,7 @@ def process_args(args):
 
     # -v
     if args.v:
-        print(f"wal {VERSION}")
+        print(f"wal {__version__}")
         exit(0)
 
     # -i
@@ -572,6 +571,3 @@ def main():
     # This saves 10ms.
     # pylint: disable=W0212
     # os._exit(0)
-
-
-main()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """wal - setup.py"""
 from setuptools import setup
 
+import pywal
 
 DESC = (
     "View the DOCS at: https://github.com/dylanaraps/pywal\n\n"
@@ -9,22 +10,30 @@ DESC = (
 )
 DESC = "".join(DESC)
 
+version = pywal.__version__
+download_url = f"https://github.com/dylanaraps/pywal/archive/{version}.tar.gz"
 
 setup(
     name="pywal",
-    version="0.1.6",
+    version=version,
     author="Dylan Araps",
     author_email="dylan.araps@gmail.com",
     description="🎨 Generate and change colorschemes on the fly",
     long_description=DESC,
     license="MIT",
     url="https://github.com/dylanaraps/pywal",
-    download_url="https://github.com/dylanaraps/pywal/archive/0.1.6.tar.gz",
-    scripts=["wal"],
+    download_url=download_url,
     classifiers=[
         "Environment :: X11 Applications",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3.6",
-    ]
+    ],
+    packages=['pywal'],
+    entry_points={
+        "console_scripts": [
+            "wal=pywal:main"
+        ]
+    },
+    python_requires=">=3.6"
 )


### PR DESCRIPTION
- Switch to distributing pywal as a module and having setuptools register
  the script as an console_script entry point.

- Added python_requires field to setuptools.setup.

- Use the module version as the package version.