### PR TITLE
os: Add support for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ If your terminal's background color is now red, your terminal should work with `
 
 - Konsole. [#24](https://github.com/dylanaraps/pywal/issues/24)
 - Alacritty. [#37](https://github.com/dylanaraps/pywal/issues/37)
+- Iterm.
+- Hyper.
+- Terminal.app.
 
 ## Installation
 

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -2,11 +2,9 @@
 Send sequences to all open terminals.
 """
 import glob
-import os
-import platform
 import re
 
-from pywal.settings import CACHE_DIR
+from pywal.settings import CACHE_DIR, OS
 from pywal import util
 
 
@@ -49,13 +47,12 @@ def create_sequences(colors, vte):
 def send_sequences(colors, vte):
     """Send colors to all open terminals."""
     sequences = create_sequences(colors, vte)
-    kernel = platform.uname()[0]
 
     # Get the pseudo terminal directory.
-    if kernel == "Linux":
+    if OS == "Linux":
         tty_pattern = "/dev/pts/[0-9]*"
 
-    elif kernel == "Darwin":
+    elif OS == "Darwin":
         tty_pattern = "/dev/ttys[0-9]*"
 
     # Create a list of psuedo terminals.

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -8,13 +8,51 @@ from pywal.settings import CACHE_DIR, OS
 from pywal import util
 
 
+def get_color_name(index):
+    """Get the color name from a number."""
+    return {
+        "0":  "black",
+        "1":  "red",
+        "2":  "green",
+        "3":  "yellow",
+        "4":  "blue",
+        "5":  "magenta",
+        "6":  "cyan",
+        "7":  "white",
+        "8":  "br_black",
+        "9":  "br_red",
+        "10": "br_green",
+        "11": "br_yellow",
+        "12": "br_blue",
+        "13": "br_magenta",
+        "14": "br_cyan",
+        "15": "br_white",
+    }.get(index, "black")
+
+
+def get_special_name(index):
+    """Get the color name from special number."""
+    return {
+        "10": "fg",
+        "11": "bg",
+        "12": "curfg",
+        "13": "curfg",
+    }.get(index, "black")
+
+
 def set_special(index, color):
     """Convert a hex color to a special sequence."""
+    if OS == "Darwin":
+        return f"\033]1337;SetColors={get_color_name(index)}={color}\a"
+
     return f"\033]{index};{color}\007"
 
 
 def set_color(index, color):
     """Convert a hex color to a text color sequence."""
+    if OS == "Darwin":
+        return f"\033]1337;SetColors={get_color_name(index)}={color}\a"
+
     return f"\033]4;{index};{color}\007"
 
 

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -55,7 +55,7 @@ def send_sequences(colors, vte):
     elif OS == "Darwin":
         tty_pattern = "/dev/ttys[0-9]*"
 
-    # Create a list of psuedo terminals.
+    # Create a list of pseudo terminals.
     terminals = [term for term in glob.glob(tty_pattern)]
 
     # Send sequences to cache file as well.

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -53,7 +53,7 @@ def send_sequences(colors, vte):
         tty_pattern = "/dev/pts/[0-9]*"
 
     elif OS == "Darwin":
-        tty_pattern = "/dev/ttys[0-9]*"
+        tty_pattern = "/dev/ttys00[0-9]*"
 
     # Create a list of pseudo terminals.
     terminals = [term for term in glob.glob(tty_pattern)]

--- a/pywal/settings.py
+++ b/pywal/settings.py
@@ -2,6 +2,7 @@
 Global Constants.
 """
 import pathlib
+import platform
 
 
 __version__ = "0.4.0"
@@ -9,3 +10,4 @@ __version__ = "0.4.0"
 
 COLOR_COUNT = 16
 CACHE_DIR = pathlib.Path.home() / ".cache/wal/"
+OS = platform.uname()[0]

--- a/pywal/templates/colors
+++ b/pywal/templates/colors
@@ -1,0 +1,16 @@
+{color0}
+{color1}
+{color2}
+{color3}
+{color4}
+{color5}
+{color6}
+{color7}
+{color8}
+{color9}
+{color10}
+{color11}
+{color12}
+{color13}
+{color14}
+{color15}

--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 
+from pywal.settings import OS
 from pywal import util
 
 
@@ -87,7 +88,14 @@ def set_wallpaper(img):
 
     desktop = get_desktop_env()
 
-    if desktop:
+    if OS == "Darwin":
+        subprocess.Popen(["sqlite3",
+                          "~/Library/Application Support/Dock/\
+                           desktoppicture.db",
+                          f"update data set value = '{img}'"])
+        subprocess.Popen(["killall", "Dock"])
+
+    elif desktop:
         set_desktop_wallpaper(desktop, img)
 
     else:


### PR DESCRIPTION
Note: For those who read this.

Support for macOS is possible (iTerm2 only), the only issue is that I can't get a macOS machine I can test on. What I need to test is iTerm2's proprietary escape sequences. 

iTerm2 supports a similar sequence to the Linux terminals to change colors but it works differently and the reference page in the docs isn't very clear. 

Here's the page (Scroll down to "Change the color palette"): 

> https://www.iterm2.com/documentation-escape-codes.html

> Change the color palette
>
> `^[]Pnrrggbb^[\`
>
> Replace "n" with:
>
>    `0-f (hex) = ansi color`
    `g = foreground`
    `h = background`
    `i = bold color`
    `j = selection color`
    `k = selected text color`
   ` l = cursor`
    `m = cursor text`
>
> rr, gg, bb are 2-digit hex value (for example, "ff"). Example in bash that changes the foreground color blue:
>
> `echo -e "\033]Pg4040ff\033\\"`

Basically what we need to figure out is the exact sequences we need to modify `background`, `foreground`, `cursor` and colors `0-15`. If anyone with a macOS system would like to test I'd be grateful as I can't find these sequences in use anywhere as a reference.

More info:

- https://gitlab.com/gnachman/iterm2/issues/454