### PR TITLE
Added KDE support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 before_install:
     - sudo apt-get -qq update
-    - sudo apt-get install -y imagemagick
+    - sudo apt-get install -y imagemagick dbus
 
 install:
     - pip install flake8 pylint dbus-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
     - sudo apt-get install -y imagemagick
 
 install:
-    - pip install flake8 pylint
+    - pip install flake8 pylint dbus-python
 
 script:
     - flake8 pywal tests setup.py

--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import subprocess
+import dbus # I didn't manage to do this on the command line using qdbus
 
 from pywal import util
 
@@ -23,7 +24,10 @@ def get_desktop_env():
     desktop = os.environ.get("MATE_DESKTOP_SESSION_ID")
     if desktop:
         return "MATE"
-
+    
+    desktop = os.environ.get("KDE_SESSION_UID") # I think
+    if desktop:
+        return "KDE"
 
 def xfconf(path, img):
     """Call xfconf to set the wallpaper on XFCE."""
@@ -75,6 +79,21 @@ def set_desktop_wallpaper(desktop, img):
     elif "mate" in desktop:
         subprocess.Popen(["gsettings", "set", "org.mate.background",
                           "picture-filename", img])
+    elif "kde" in desktop:
+        jscript = """
+        var allDesktops = desktops();
+        print (allDesktops);
+        for (i=0;i<allDesktops.length;i++) {
+            d = allDesktops[i];
+            d.wallpaperPlugin = "org.kde.image";
+            d.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");
+            d.writeConfig("Image", "file://%s")
+        }
+        """
+        # Using the modulo operator is faster than using str.format
+        bus = dbus.SessionBus()
+        plasma = dbus.Interface(bus.get_object('org.kde.plasmashell', '/PlasmaShell'), dbus_interface='org.kde.PlasmaShell')
+        plasma.evaluateScript(jscript % img)       
 
     else:
         set_wm_wallpaper(img)

--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -79,6 +79,7 @@ def set_desktop_wallpaper(desktop, img):
     elif "mate" in desktop:
         subprocess.Popen(["gsettings", "set", "org.mate.background",
                           "picture-filename", img])
+        
     elif "kde" in desktop:
         jscript = """
         var allDesktops = desktops();


### PR DESCRIPTION
The code I used is ripped from [here](https://github.com/pashazz/ksetwallpaper/blob/master/ksetwallpaper.py)

This *should* work but I don't know if it does (changing the wallpaper manually through the python REPL works so if this is the only bit of code that I needed to add it should be ok).  
If anyone can get the command-line method from [here](https://bbs.archlinux.org/viewtopic.php?id=215899) to work (using qdbus to send the message/whatever you call it) it would get rid of the dbus dependancy.