### PR TITLE
os: Add support for macOS (Take 2)

### DIFF
--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -56,7 +56,9 @@ def sort_colors(img, colors):
     raw_colors = colors[:1] + colors[9:] + colors[8:]
 
     # Darken the background color if it's too light.
-    if int(raw_colors[0][1]) >= 3:
+    # The value can be a letter or an it so we treat the
+    # entire test as strings.
+    if raw_colors[0][1] not in ["0", "1", "2"]:
         raw_colors[0] = util.darken_color(raw_colors[0], 0.25)
 
     colors = {"wallpaper": img}

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -2,15 +2,17 @@
 Send sequences to all open terminals.
 """
 import glob
-import os
 
 from .settings import CACHE_DIR, OS
 from . import util
 
 
-def set_special(index, color):
+def set_special(index, color, iterm_name):
     """Convert a hex color to a special sequence."""
     alpha = util.Color.alpha_num
+
+    if OS == "Darwin":
+        return f"\033]P{iterm_name}{color.strip('#')}\033\\"
 
     if index in [11, 708] and alpha != 100:
         return f"\033]{index};[{alpha}]{color}\007"
@@ -36,10 +38,10 @@ def create_sequences(colors, vte):
     # Source: https://goo.gl/KcoQgP
     # 10 = foreground, 11 = background, 12 = cursor foregound
     # 13 = mouse foreground
-    sequences.append(set_special(10, colors["special"]["foreground"]))
-    sequences.append(set_special(11, colors["special"]["background"]))
-    sequences.append(set_special(12, colors["special"]["cursor"]))
-    sequences.append(set_special(13, colors["special"]["cursor"]))
+    sequences.append(set_special(10, colors["special"]["foreground"], "g"))
+    sequences.append(set_special(11, colors["special"]["background"], "h"))
+    sequences.append(set_special(12, colors["special"]["cursor"], "l"))
+    sequences.append(set_special(13, colors["special"]["cursor"], "l"))
 
     # Set a blank color that isn't affected by bold highlighting.
     # Used in wal.vim's airline theme.

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -3,7 +3,7 @@ Send sequences to all open terminals.
 """
 import os
 
-from .settings import CACHE_DIR
+from .settings import CACHE_DIR, OS
 from . import util
 
 
@@ -19,6 +19,9 @@ def set_special(index, color):
 
 def set_color(index, color):
     """Convert a hex color to a text color sequence."""
+    if OS == "Darwin":
+        return f"\033]P{index:x}{color.strip('#')}\033\\"
+
     return f"\033]4;{index};{color}\007"
 
 

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -45,7 +45,7 @@ def create_sequences(colors, vte):
 
     # Set a blank color that isn't affected by bold highlighting.
     # Used in wal.vim's airline theme.
-    sequences.append(set_color(66, colors["special"]["background"], "h"))
+    sequences.append(set_color(66, colors["special"]["background"]))
 
     # This escape sequence doesn"t work in VTE terminals.
     if not vte:

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -7,7 +7,7 @@ from .settings import CACHE_DIR, OS
 from . import util
 
 
-def set_special(index, color, iterm_name):
+def set_special(index, color, iterm_name="g"):
     """Convert a hex color to a special sequence."""
     alpha = util.Color.alpha_num
 
@@ -45,7 +45,7 @@ def create_sequences(colors, vte):
 
     # Set a blank color that isn't affected by bold highlighting.
     # Used in wal.vim's airline theme.
-    sequences.append(set_color(66, colors["special"]["background"]))
+    sequences.append(set_color(66, colors["special"]["background"], "h"))
 
     # This escape sequence doesn"t work in VTE terminals.
     if not vte:

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -63,7 +63,7 @@ def send(colors, vte, cache_dir=CACHE_DIR):
 
     else:
         tty_pattern = "/dev/pts/[0-9]*"
-        
+
     # Writing to "/dev/pts/[0-9] lets you send data to open terminals.
     for term in glob.glob(tty_pattern):
         util.save_file(sequences, term)

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -7,7 +7,7 @@ from .settings import CACHE_DIR, OS
 from . import util
 
 
-def set_special(index, color, iterm_name="g"):
+def set_special(index, color, iterm_name="h"):
     """Convert a hex color to a special sequence."""
     alpha = util.Color.alpha_num
 

--- a/pywal/settings.py
+++ b/pywal/settings.py
@@ -10,6 +10,7 @@ Created by Dylan Araps.
 """
 
 import pathlib
+import platform
 
 
 __version__ = "0.5.7"
@@ -19,3 +20,4 @@ HOME = pathlib.Path.home()
 CACHE_DIR = HOME / ".cache/wal/"
 MODULE_DIR = pathlib.Path(__file__).parent
 COLOR_COUNT = 16
+OS = platform.uname()[0]


### PR DESCRIPTION
This PR adds support for macOS (iTerm2 only).

Can those with access to a macOS machine with iTerm2 test this PR for me? 

TODO:

- [ ] Add wallpaper support.
    - [ ] `osascript` command for older versions of macOS.
    - [ ] `sqlite3` command for newer versions of macOS.
- [x] Verify that the escape sequences work.

**Those of you using macOS and would like to help test:**

Do any of these commands change iTerm2's background color to `#FFFFFF`?

```sh
printf "%b\n" "\033]\a1337;SetColors=bg=FFFFFF"
printf "%b\n" "\033]PhFFFFFF\033\\"
```

Sources: 

- https://www.iterm2.com/documentation-escape-codes.html
- https://github.com/gnachman/iTerm2/blob/master/tests/setpal
- https://gitlab.com/gnachman/iterm2/issues/454
- https://github.com/gnachman/iTerm2/blob/master/tests/set_colors.applescript
- https://github.com/gnachman/iTerm2/blob/master/tests/it2setcolor