### PR TITLE
Fixes reload wallpaper weirdness and adds -e option

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -65,6 +65,9 @@ def get_args(args):
     arg.add_argument("-v", action="store_true",
                      help="Print \"wal\" version.")
 
+    arg.add_argument("-e", action="store_true",
+                     help="Skip Reloading Environment gtk/xrdb/i3/polybar")
+
     return arg.parse_args(args)
 
 
@@ -114,7 +117,9 @@ def process_args(args):
             wallpaper.change(colors_plain["wallpaper"])
 
         export.every(colors_plain)
-        reload.env()
+
+        if not args.e:
+            reload.env()
 
     if args.o:
         util.disown([args.o])

--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -83,14 +83,7 @@ def set_desktop_wallpaper(desktop, img):
 
 def set_mac_wallpaper(img):
     """Set the wallpaper on macOS."""
-    db_file = HOME / "Library/Application Support/Dock/desktoppicture.db"
-    subprocess.call(["sqlite3", db_file, f"update data set value = '{img}'"])
-
-    # Kill the dock to fix issues with cached wallpapers.
-    # macOS caches wallpapers and if a wallpaper is set that shares
-    # the filename with a cached wallpaper, the cached wallpaper is
-    # used instead.
-    util.disown(["killall", "Dock"])
+    subprocess.Popen(f"""osascript -e 'tell application "Finder" to set desktop picture to POSIX file "{img}"'""", shell=True)
 
 
 def change(img):

--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -83,7 +83,14 @@ def set_desktop_wallpaper(desktop, img):
 
 def set_mac_wallpaper(img):
     """Set the wallpaper on macOS."""
-    subprocess.Popen(f"""osascript -e 'tell application "Finder" to set desktop picture to POSIX file "{img}"'""", shell=True)
+    db_file = HOME / "Library/Application Support/Dock/desktoppicture.db"
+    subprocess.call(["sqlite3", db_file, f"update data set value = '{img}'"])
+
+    # Kill the dock to fix issues with cached wallpapers.
+    # macOS caches wallpapers and if a wallpaper is set that shares
+    # the filename with a cached wallpaper, the cached wallpaper is
+    # used instead.
+    subprocess.call(["killall", "Dock"])
 
 
 def change(img):

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -29,6 +29,11 @@ class Testsequences(unittest.TestCase):
         result = sequences.set_color(11, COLORS["colors"]["color0"])
         self.assertEqual(result, "\033]4;11;#1F211E\007")
 
+    def test_set_iterm_tab_color(self):
+        """> Create iterm tab color sequences"""
+        result = sequences.set_iterm_tab_color(COLORS["special"]["background"])
+        self.assertEqual(len(result), 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
On mac, the reload env function is opening up the x11 app for me, and if it's not already open, makes wal super slow. This adds an option to bypass this.