### PR TITLE
Fix non-transparent border on newly spawned urxvt terminals

### DIFF
--- a/pywal/templates/colors.Xresources
+++ b/pywal/templates/colors.Xresources
@@ -9,7 +9,7 @@ UXTerm*background:  {background}
 URxvt*cursorColor:  {cursor}
 XTerm*cursorColor:  {cursor}
 UXTerm*cursorColor: {cursor}
-URxvt*borderColor:  {background}
+URxvt*borderColor:  {background.alpha}
 
 ! Colors 0-15.
 *.color0: {color0}


### PR DESCRIPTION
This PR uses `{background.alpha}` for `URxvt*borderColor` in the Xresources template so that `urxvt` terminal borders share the same transparency as the terminal background.

For example, this is `xrdb -q` on an affected terminal:

![image](https://user-images.githubusercontent.com/14209781/29374924-29fd1efa-8281-11e7-9628-60aa45faf84c.png)
