### PR TITLE
Clean up travis and get python working on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
-language: python
-python:
-    - "3.5"
-    - "3.6"
-
-os:
-    - "linux"
-    - "osx"
-
-before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo brew install imagemagick; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y imagemagick; fi
-
-install:
-    - pip install flake8 pylint
-
-script:
-    - flake8 pywal tests setup.py
-    - pylint pywal tests setup.py
-    - python setup.py test
+matrix:
+  include:
+    - os: linux
+      language: python
+      sudo: required
+      python: 3.5
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get -y install imagemagick
+    - os: linux
+      language: python
+      sudo: required
+      python: 3.6
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get -y install imagemagick
+    - os: osx
+      language: generic
+      before_install:
+        - brew install imagemagick
+        - brew install python3
+        - brew link --overwite python3
+script: python3 setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,15 @@ python:
     - "3.5"
     - "3.6"
 
+os:
+    - "linux"
+    - "osx"
+
 before_install:
-    - sudo apt-get -qq update
-    - sudo apt-get install -y imagemagick
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install imagemagick; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; sudo apt-get -qq update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; sudo apt-get install -y imagemagick; fi
 
 install:
     - pip install flake8 pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ os:
     - "osx"
 
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install imagemagick; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; sudo apt-get -qq update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; sudo apt-get install -y imagemagick; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo brew update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo brew install imagemagick; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y imagemagick; fi
 
 install:
     - pip install flake8 pylint

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    #brew install imagemagick
+    #brew install python && brew link --overwite python3
+else
+   sudo apt-get -qq update
+   sudo apt-get install -y imagemagick
+fi

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-    #brew install imagemagick
-    #brew install python && brew link --overwite python3
-else
-   sudo apt-get -qq update
-   sudo apt-get install -y imagemagick
-fi


### PR DESCRIPTION
This uses homebrew on OSX to install python 3.6 since travis-ci has a bug with installing it.  

It also removes the pylint and flakes8 since they are easier to run with git-commit-hooks.  You can install them with `pip install git-pylint-commit-hooks` and `flake8 --install-hook git`.  

I also removed python 3.5 for OSX since there should not be anyone running it.  OSX comes with 2.7 and homebrew will install 3.6.

Currently all tests pass except for the ones listed in #102 