### PR TITLE
Use run instead of popen so that things are closed correctly

### DIFF
--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -18,12 +18,12 @@ def imagemagick(color_count, img):
     else:
         magick_command = ["convert"]
 
-    colors = subprocess.Popen([*magick_command, img, "-resize", "25%",
-                               "+dither", "-colors", str(color_count),
-                               "-unique-colors", "txt:-"],
-                              stdout=subprocess.PIPE)
+    colors = subprocess.run([*magick_command, img, "-resize", "25%",
+                             "+dither", "-colors", str(color_count),
+                             "-unique-colors", "txt:-"],
+                            stdout=subprocess.PIPE)
 
-    return colors.stdout.readlines()
+    return colors.stdout.splitlines()
 
 
 def gen_colors(img, color_count):


### PR DESCRIPTION
Popen has more power than what is needed for running image magick.  If we use run() there will no longer be resources left open by the sub-process, so we get better house keeping.