### PR TITLE
Fix YAML template

### DIFF
--- a/pywal/templates/colors.yml
+++ b/pywal/templates/colors.yml
@@ -7,7 +7,7 @@ special:
 
 colors:
     color0: "{color0}"
-    color": "{color1}"
+    color1: "{color1}"
     color2: "{color2}"
     color3: "{color3}"
     color4: "{color4}"


### PR DESCRIPTION
The template for YAML currently exports `color"` in place of `color1` and needs to be fixed.