### PR TITLE
general: Added user template support.

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -3,7 +3,7 @@ Export colors in various formats.
 """
 import os
 
-from .settings import CACHE_DIR, MODULE_DIR
+from .settings import CACHE_DIR, MODULE_DIR, CONF_DIR
 from . import util
 
 
@@ -42,13 +42,19 @@ def get_export_type(export_type):
 
 def every(colors, output_dir=CACHE_DIR):
     """Export all template files."""
-    all_colors = flatten_colors(colors)
+    colors = flatten_colors(colors)
     template_dir = os.path.join(MODULE_DIR, "templates")
+    template_dir_user = os.path.join(CONF_DIR, "templates")
+    util.create_dir(template_dir_user)
 
     for file in os.scandir(template_dir):
-        template(all_colors, file.path, os.path.join(output_dir, file.name))
+        template(colors, file.path, os.path.join(output_dir, file.name))
+
+    for file in os.scandir(template_dir_user):
+        template(colors, file.path, os.path.join(output_dir, file.name))
 
     print("export: Exported all files.")
+    print("export: Exported all user files.")
 
 
 def color(colors, export_type, output_file=None):

--- a/pywal/settings.py
+++ b/pywal/settings.py
@@ -19,5 +19,6 @@ __version__ = "0.7.3"
 HOME = os.getenv("HOME", os.getenv("USERPROFILE"))
 CACHE_DIR = os.path.join(HOME, ".cache", "wal")
 MODULE_DIR = os.path.dirname(__file__)
+CONF_DIR = os.path.join(HOME, ".config", "wal")
 COLOR_COUNT = 16
 OS = platform.uname()[0]

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -33,6 +33,11 @@ class Color:
         """Add URxvt alpha value to color."""
         return "[%s]%s" % (self.alpha_num, self.hex_color)
 
+    @property
+    def strip(self):
+        """Strip '#' from color."""
+        return self.hex_color[1:]
+
 
 def read_file(input_file):
     """Read data from a file and trim newlines."""


### PR DESCRIPTION
You can now create your own template files for use with `pywal`. 

The template files work the exact same way as the built-in files that exist in `~/.cache/wal`, only now you can define your own custom files. The user created files are read from `~/.config/wal/templates` and are exported to `~/.cache/wal`. 

Using this new feature you can also overwrite the built-in files if you need to customize them further. For example; Creating `colors.css` in your user folder will overwrite the built-in `pywal` file.

For a list of the built-in files and for example syntax; see the default list of templates: https://github.com/dylanaraps/pywal/tree/master/pywal/templates

### Example usage (Create a pywal template file for TOML):

1. Create a file called `colors.toml` in `~/.config/wal/templates`.
2. Populate the file.

```toml
# Generated by "wal"
wallpaper = "{wallpaper}"

# Special
background = "{background}"
foreground = "{foreground}"
cursor = "{cursor}"

# Colors
color0 = "{color0}"
color1 = "{color1}"
color2 = "{color2}"
color3 = "{color3}"
color4 = "{color4}"
color5 = "{color5}"
color6 = "{color6}"
color7 = "{color7}"
color8 = "{color8}"
color9 = "{color9}"
color10 = "{color10}"
color11 = "{color11}"
color12 = "{color12}"
color13 = "{color13}"
color14 = "{color14}"
color15 = "{color15}"
```

3. Run `wal` and it will process the file and export it to: `~/.cache/wal/colors.toml`

```toml
# Generated by "wal"
wallpaper = "/home/dylan/Pictures/Wallpapers/B006254-R1-16-11.JPG"

# Special
background = "#1C2323"
foreground = "#E7E4E4"
cursor = "#E7E4E4"

# Colors
color0 = "#1C2323"
color1 = "#CAAB93"
color2 = "#C5B8B3"
color3 = "#C7CAC6"
color4 = "#CDDDEB"
color5 = "#D8E2ED"
color6 = "#D8E4F0"
color7 = "#E7E4E4"
color8 = "#767b7b"
color9 = "#CAAB93"
color10 = "#C5B8B3"
color11 = "#C7CAC6"
color12 = "#CDDDEB"
color13 = "#D8E2ED"
color14 = "#D8E4F0"
color15 = "#E7E4E4"
```

4. Use the newly generated `colors.toml` file in scripts etc.

### Example conversion syntax

```
# HEX
{color0}

# RGB
{color0.rgb}

# XRDB RGBA
{color0.xrgb}

# URXVT ALPHA
{color0.alpha}

# HEX (NO '#')
{color0.strip}

# HEX with ALPHA 
color0 = "#22{color0.strip}"
```