### PR TITLE
general: Remove -a

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -29,10 +29,6 @@ def get_args(args):
     description = "wal - Generate colorschemes on the fly"
     arg = argparse.ArgumentParser(description=description)
 
-    arg.add_argument("-a", metavar="\"alpha\"",
-                     help="Set terminal background transparency. \
-                           *Only works in URxvt*")
-
     arg.add_argument("-b", metavar="background",
                      help="Custom background color to use.")
 
@@ -103,9 +99,6 @@ def process_args(args):
     if args.c:
         scheme_dir = os.path.join(CACHE_DIR, "schemes")
         shutil.rmtree(scheme_dir, ignore_errors=True)
-
-    if args.a:
-        util.Color.alpha_num = args.a
 
     if args.R:
         image_file = os.path.join(CACHE_DIR, "wal")

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -10,13 +10,8 @@ from . import util
 
 def set_special(index, color, iterm_name="h"):
     """Convert a hex color to a special sequence."""
-    alpha = util.Color.alpha_num
-
     if OS == "Darwin":
         return "\033]P%s%s\033\\" % (iterm_name, color.strip("#"))
-
-    if index in [11, 708] and alpha != 100:
-        return "\033]%s;[%s]%s\033\\" % (index, alpha, color)
 
     return "\033]%s;%s\033\\" % (index, color)
 

--- a/pywal/templates/colors-urxvt.Xresources
+++ b/pywal/templates/colors-urxvt.Xresources
@@ -1,0 +1,2 @@
+URxvt*background:   [100]{background}
+URxvt*borderColor:  [100]{background}

--- a/pywal/templates/colors.Xresources
+++ b/pywal/templates/colors.Xresources
@@ -7,13 +7,13 @@ emacs*background:   {background}
 URxvt*foreground:   {foreground}
 XTerm*foreground:   {foreground}
 UXTerm*foreground:  {foreground}
-URxvt*background:   {background.alpha}
+URxvt*background:   {background}
 XTerm*background:   {background}
 UXTerm*background:  {background}
 URxvt*cursorColor:  {cursor}
 XTerm*cursorColor:  {cursor}
 UXTerm*cursorColor: {cursor}
-URxvt*borderColor:  {background.alpha}
+URxvt*borderColor:  {background}
 
 ! Colors 0-15.
 *.color0: {color0}
@@ -64,3 +64,5 @@ XClock*secondColor: rgba:{color15.xrgba}
 
 ! Set depth to make transparency work.
 URxvt*depth: 32
+
+#include "colors-urxvt.Xresources"

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -9,8 +9,6 @@ import subprocess
 
 class Color:
     """Color formats."""
-    alpha_num = 100
-
     def __init__(self, hex_color):
         self.hex_color = hex_color
 

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -29,11 +29,6 @@ class Color:
         return hex_to_xrgba(self.hex_color)
 
     @property
-    def alpha(self):
-        """Add URxvt alpha value to color."""
-        return "[%s]%s" % (self.alpha_num, self.hex_color)
-
-    @property
     def strip(self):
         """Strip '#' from color."""
         return self.hex_color[1:]


### PR DESCRIPTION
User templates now allow this with more control.

Alternative way to modify transparency:

1. Create a file called `colors-urxvt.Xresources` in `~/.config/wal/templates`.
2. Add these lines to the file and modify the alpha to your liking:

```cfg
URxvt*background:   [100]{background}
URxvt*borderColor:  [100]{background}
```

3. Run `wal`


Closes #120 