### PR TITLE
Use separate versioning for cache files and pywal.

### DIFF
--- a/pywal/__init__.py
+++ b/pywal/__init__.py
@@ -9,7 +9,7 @@
 Created by Dylan Araps.
 """
 
-from .settings import __version__, __chache_version__
+from .settings import __version__, __cache_version__
 from . import colors
 from . import export
 from . import image
@@ -19,7 +19,7 @@ from . import wallpaper
 
 __all__ = [
     "__version__",
-    "__chache_version__",
+    "__cache_version__",
     "colors",
     "export",
     "image",

--- a/pywal/__init__.py
+++ b/pywal/__init__.py
@@ -19,7 +19,7 @@ from . import wallpaper
 
 __all__ = [
     "__version__",
-    "__chache_version__"
+    "__chache_version__",
     "colors",
     "export",
     "image",

--- a/pywal/__init__.py
+++ b/pywal/__init__.py
@@ -9,7 +9,7 @@
 Created by Dylan Araps.
 """
 
-from .settings import __version__, __template_version__
+from .settings import __version__, __chache_version__
 from . import colors
 from . import export
 from . import image
@@ -19,7 +19,7 @@ from . import wallpaper
 
 __all__ = [
     "__version__",
-    "__template_version__"
+    "__chache_version__"
     "colors",
     "export",
     "image",

--- a/pywal/__init__.py
+++ b/pywal/__init__.py
@@ -9,7 +9,7 @@
 Created by Dylan Araps.
 """
 
-from .settings import __version__
+from .settings import __version__, __template_version__
 from . import colors
 from . import export
 from . import image
@@ -19,6 +19,7 @@ from . import wallpaper
 
 __all__ = [
     "__version__",
+    "__template_version__"
     "colors",
     "export",
     "image",

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -15,7 +15,6 @@ import shutil
 import sys
 
 from .settings import __version__, CACHE_DIR
-from .settings import __chache_version__
 from . import colors
 from . import export
 from . import image

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -15,7 +15,7 @@ import shutil
 import sys
 
 from .settings import __version__, CACHE_DIR
-from .settings import __template_version__
+from .settings import __chache_version__
 from . import colors
 from . import export
 from . import image

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -15,6 +15,7 @@ import shutil
 import sys
 
 from .settings import __version__, CACHE_DIR
+from .settings import __template_version__
 from . import colors
 from . import export
 from . import image

--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 
-from .settings import CACHE_DIR, COLOR_COUNT, __chache_version__
+from .settings import CACHE_DIR, COLOR_COUNT, __cache_version__
 from . import util
 
 
@@ -106,7 +106,7 @@ def get(img, cache_dir=CACHE_DIR,
     color_type = "light" if light else "dark"
     cache_file = re.sub("[/|\\|.]", "_", img)
     cache_file = os.path.join(cache_dir, "schemes", "%s_%s_%s.json"
-                              % (cache_file, color_type, __chache_version__))
+                              % (cache_file, color_type, __cache_version__))
 
     if os.path.isfile(cache_file):
         colors = file(cache_file)

--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 
-from .settings import CACHE_DIR, COLOR_COUNT, __template_version__
+from .settings import CACHE_DIR, COLOR_COUNT, __chache_version__
 from . import util
 
 
@@ -106,7 +106,7 @@ def get(img, cache_dir=CACHE_DIR,
     color_type = "light" if light else "dark"
     cache_file = re.sub("[/|\\|.]", "_", img)
     cache_file = os.path.join(cache_dir, "schemes", "%s_%s_%s.json"
-                              % (cache_file, color_type, __template_version__))
+                              % (cache_file, color_type, __chache_version__))
 
     if os.path.isfile(cache_file):
         colors = file(cache_file)

--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 
-from .settings import CACHE_DIR, COLOR_COUNT, __version__
+from .settings import CACHE_DIR, COLOR_COUNT, __template_version__
 from . import util
 
 
@@ -106,7 +106,7 @@ def get(img, cache_dir=CACHE_DIR,
     color_type = "light" if light else "dark"
     cache_file = re.sub("[/|\\|.]", "_", img)
     cache_file = os.path.join(cache_dir, "schemes", "%s_%s_%s.json"
-                              % (cache_file, color_type, __version__))
+                              % (cache_file, color_type, __template_version__))
 
     if os.path.isfile(cache_file):
         colors = file(cache_file)

--- a/pywal/settings.py
+++ b/pywal/settings.py
@@ -14,7 +14,7 @@ import platform
 
 
 __version__ = "1.3.1"
-__template_version__ = "1.0.0"
+__chache_version__ = "1.0.0"
 
 
 HOME = os.getenv("HOME", os.getenv("USERPROFILE"))

--- a/pywal/settings.py
+++ b/pywal/settings.py
@@ -13,7 +13,7 @@ import os
 import platform
 
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __template_version__ = "1.0.0"
 
 

--- a/pywal/settings.py
+++ b/pywal/settings.py
@@ -14,6 +14,7 @@ import platform
 
 
 __version__ = "1.3.0"
+__template_version__ = "1.0.0"
 
 
 HOME = os.getenv("HOME", os.getenv("USERPROFILE"))

--- a/pywal/settings.py
+++ b/pywal/settings.py
@@ -14,7 +14,7 @@ import platform
 
 
 __version__ = "1.3.1"
-__chache_version__ = "1.0.0"
+__cache_version__ = "1.0.0"
 
 
 HOME = os.getenv("HOME", os.getenv("USERPROFILE"))


### PR DESCRIPTION
Since not every `pywal` release makes breaking changes to the cache files themselves, I think it's appropriate to manage two different version numbers, one for the cache files and the one for `pywal` itself, this way the cache files get ignored only on breaking changes, not on every `pywal` release