### PR TITLE
Fixed issue with .DS_Store files

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -58,10 +58,12 @@ def every(colors, output_dir=CACHE_DIR):
     join = os.path.join  # Minor optimization.
 
     for file in os.scandir(template_dir):
-        template(colors, file.path, join(output_dir, file.name))
+        if file.name != '.DS_Store':
+            template(colors, file.path, join(output_dir, file.name))
 
     for file in os.scandir(template_dir_user):
-        template(colors, file.path, join(output_dir, file.name))
+        if file.name != '.DS_Store':
+            template(colors, file.path, join(output_dir, file.name))
 
     print("export: Exported all files.")
     print("export: Exported all user files.")


### PR DESCRIPTION
MacOS could create a .DS_Store file in one of the folders if a .plist file was introduced. This PR introduces a check that .DS_Store files are not evaluated as templates which breaks the entire program if done. 