### PR TITLE
Save sequences file even with -s

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -137,8 +137,7 @@ def process_args(args):
         if not args.n:
             wallpaper.change(colors_plain["wallpaper"])
 
-        if not args.s:
-            sequences.send(colors_plain)
+        sequences.send(colors_plain, to_send=not args.s)
 
         export.every(colors_plain)
 

--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -73,7 +73,7 @@ def create_sequences(colors):
     return "".join(sequences)
 
 
-def send(colors, cache_dir=CACHE_DIR):
+def send(colors, cache_dir=CACHE_DIR, to_send=True):
     """Send colors to all open terminals."""
     if OS == "Darwin":
         tty_pattern = "/dev/ttys00[0-9]*"
@@ -84,8 +84,9 @@ def send(colors, cache_dir=CACHE_DIR):
     sequences = create_sequences(colors)
 
     # Writing to "/dev/pts/[0-9] lets you send data to open terminals.
-    for term in glob.glob(tty_pattern):
-        util.save_file(sequences, term)
+    if to_send:
+        for term in glob.glob(tty_pattern):
+            util.save_file(sequences, term)
 
     util.save_file(sequences, os.path.join(cache_dir, "sequences"))
     print("colors: Set terminal colors.")


### PR DESCRIPTION
Pretty simple fix for #207 .  
Didn't want to change parameters of `send` or add overhead with an extra `save` function that `send` would call anyway, so I just added a kwarg to `send`.