### PR TITLE
Fix rofi template

### DIFF
--- a/pywal/templates/colors-rofi-dark.rasi
+++ b/pywal/templates/colors-rofi-dark.rasi
@@ -130,6 +130,10 @@ textbox-prompt-colon {{
     border-color: @border-color;
 }}
 
+#button {{
+    text-color: @normal-foreground;
+}}
+
 #button.selected {{
     background-color: @selected-normal-background;
     text-color: @selected-normal-foreground;

--- a/pywal/templates/colors-rofi-light.rasi
+++ b/pywal/templates/colors-rofi-light.rasi
@@ -130,6 +130,10 @@ textbox-prompt-colon {{
     border-color: @border-color;
 }}
 
+#button {{
+    text-color: @normal-foreground;
+}}
+
 #button.selected {{
     background-color: @selected-normal-background;
     text-color: @selected-normal-foreground;


### PR DESCRIPTION
There is no default color for rofi button text, so it will become black in dark theme and be hard to see.