### PR TITLE
add missing color for newer st

### DIFF
--- a/pywal/templates/colors-wal-st.h
+++ b/pywal/templates/colors-wal-st.h
@@ -31,3 +31,4 @@ const char *colorname[] = {{
  unsigned int defaultbg = 0;
  unsigned int defaultfg = 257;
  unsigned int defaultcs = 258;
+ unsigned int defaultrcs= 258;


### PR DESCRIPTION
st needs another color to build properly. It stands for "reverse cursor" color - I just set it to be the same as the cursor color.