### PR TITLE
Fix alpha not being set correctly

### DIFF
--- a/pywal/colors.py
+++ b/pywal/colors.py
@@ -119,7 +119,7 @@ def get(img, light=False, backend="wal", cache_dir=CACHE_DIR):
         colors = theme.file(cache_file)
         logger.disabled = False
 
-        util.Color.alpha_num = colors["alpha"]
+        colors["alpha"] = util.Color.alpha_num
         logging.info("Found cached colorscheme.")
 
     else:


### PR DESCRIPTION
I'm not sure, but I believe this assignment is supposed to be the other way around. Currently, invoking wal twice with the same image but different alpha values with -a causes only the first alpha value to ever be used. Switching the assignment fixes that, since the color sequence building references colors["alpha"], not util.Color.alpha_num.