### PR TITLE
Add kitty support

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -37,6 +37,7 @@ def get_export_type(export_type):
         "gtk2": "colors-gtk2.rc",
         "json": "colors.json",
         "konsole": "colors-konsole.colorscheme",
+        "kitty": "colors-kitty.conf",
         "plain": "colors",
         "putty": "colors-putty.reg",
         "rofi": "colors-rofi.Xresources",

--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -65,6 +65,12 @@ def i3():
         util.disown(["i3-msg", "reload"])
 
 
+def kitty():
+    """ Reload kitty colors. """
+    if shutil.which("kitty"):
+        util.disown(["kitty", "@", "set-colors", "--all"])
+
+
 def polybar():
     """Reload polybar colors."""
     if shutil.which("polybar"):
@@ -92,6 +98,7 @@ def env(xrdb_file=None, tty_reload=True):
     """Reload environment."""
     xrdb(xrdb_file)
     i3()
+    kitty()
     sway()
     polybar()
     logging.info("Reloaded environment.")

--- a/pywal/templates/colors-kitty.conf
+++ b/pywal/templates/colors-kitty.conf
@@ -1,0 +1,20 @@
+foreground   {foreground}
+background   {background}
+cursor       {cursor}
+
+color0       {color0}
+color8       {color8}
+color1       {color1}
+color9       {color9}
+color2       {color2}
+color10      {color10}
+color3       {color3}
+color11      {color11}
+color4       {color4}
+color12      {color12}
+color5       {color5}
+color13      {color13}
+color6       {color6}
+color14      {color14}
+color7       {color7}
+color15      {color15}


### PR DESCRIPTION
I added a template file and a reload function for the [kitty](https://sw.kovidgoyal.net/kitty/index.html)  terminal emulator.

If this PR is accepted, consider adding an entry to the wiki on how to setup the colorscheme from the kitty config file (located in `~/.config/kitty/kitty.conf` by default):

`include ~/.cache/wal/colors-kitty.conf`