### PR TITLE
colors: add borderColor for XTerm and UXTerm

### DIFF
--- a/pywal/templates/colors.Xresources
+++ b/pywal/templates/colors.Xresources
@@ -16,6 +16,8 @@ URxvt*cursorColor:  {cursor}
 XTerm*cursorColor:  {cursor}
 UXTerm*cursorColor: {cursor}
 URxvt*borderColor:  {background.alpha}
+XTerm*borderColor:  {foreground}                                                
+UXTerm*borderColor: {foreground}
 
 ! Colors 0-15.
 *.color0: {color0}


### PR DESCRIPTION
Since xterm v334 my internal border turned completely black (as in super thick) which looked just awful.
Explicitly setting the `borderColor` fixes this.

Hope those are all the changes need in pywal...