### PR TITLE
Fix URxvt borders not respecting background opacity

### DIFF
--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -54,7 +54,7 @@ def create_sequences(colors):
         set_special(13, colors["special"]["foreground"], "l"),
         set_special(17, colors["special"]["foreground"], "l"),
         set_special(19, colors["special"]["background"], "l"),
-        set_special(708, colors["special"]["background"], "l"),
+        set_special(708, colors["special"]["background"], "l", alpha),
         set_color(232, colors["special"]["background"]),
         set_color(256, colors["special"]["foreground"])
     ])


### PR DESCRIPTION
This PR fixes URxvt borders not respecting the alpha channel. After using `wal --theme "mytheme.json" -a 75 -n`, I get a 75% alpha background, but a fully-opaque border:

<table>
<tr><th>Before</th><th>After</th><tr>
<tr>
<td><img src='https://user-images.githubusercontent.com/74385/47845500-324be100-de00-11e8-94dd-082330520d6a.png'></td>
<td><img src='https://user-images.githubusercontent.com/74385/47845754-c8800700-de00-11e8-82ae-4d31e7403edb.png'></td>
</tr>
</table>

This happens when you use `URxvt.internalBorder` to add padding around terminals, like so:

```
URxvt.internalBorder: 16
URxvt.externalBorder: 0
```

This bug only affects v3.2.1. It was introduced in this recent change:

https://github.com/dylanaraps/pywal/commit/da0e2ff05a885422dfc61fc87ae3c68ec713751b#diff-a5ddda4dbc7ee44dc1b6cc691ac053cbR57