### PR TITLE
Redoing Termite Support Pull Request

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -67,23 +67,20 @@ def every(colors, output_dir=CACHE_DIR):
 
     # Termite specific as author is too stubborn to include 'include' directive
     # in config file: https://github.com/thestinger/termite/issues/260
-    # Only triggered if user has pywal.conf in Termite config as will be
-    # explained in the Wiki.
-    # The following merges cached Termite colors and the pywal.conf file in
-    # ~/.config/termite/ into the standard ~/.config/termite/config
+    # Only triggered if user has termite-pywal.conf in ~/.config/termite as
+    # will be explained in the Wiki.
+    # `ln -s ~/.cache/wal/colors-termite.conf ~/.config/termite/config`
+    # This uses pywal colors to which termite-pywal.conf is appended as the
+    # default config file.
 
-    TERMITE_CONFIG = os.path.join(HOME, '.config/termite/config')
-    TERMITE_PYWAL_CONFIG = os.path.join(HOME, '.config/termite/pywal.conf')
-    TERMITE_PYWAL_CACHE = os.path.join(CACHE_DIR, 'colors-termite.conf')
-    if os.path.isfile(TERMITE_PYWAL_CONFIG):
-        configs = [TERMITE_PYWAL_CONFIG, TERMITE_PYWAL_CACHE]
-        if not os.path.isfile(TERMITE_CONFIG):
-            os.mknod(TERMITE_CONFIG)
-        with open(TERMITE_CONFIG, 'w') as outfile:
-            for config in configs:
-                with open(config) as infile:
-                    for line in infile:
-                        outfile.write(line)
+    termite_pywal_config = join(HOME, '.config/termite/termite-pywal.conf')
+    if os.path.isfile(termite_pywal_config):
+        termite_pywal_cache = os.path.join(CACHE_DIR, 'colors-termite.conf')
+        with open(termite_pywal_config, 'r') as not_color:
+            not_color_lines = not_color.readlines()
+        with open(termite_pywal_cache, 'a') as color:
+            color.write('\n')
+            color.writelines(not_color_lines)
 
     logging.info("Exported all files.")
     logging.info("Exported all user files.")

--- a/pywal/export.py
+++ b/pywal/export.py
@@ -77,9 +77,8 @@ def every(colors, output_dir=CACHE_DIR):
     if os.path.isfile(termite_pywal_config):
         termite_pywal_cache = os.path.join(CACHE_DIR, 'colors-termite.conf')
         with open(termite_pywal_config, 'r') as termite_config:
-            termite_config_lines = termite_config.readlines()
+            termite_config_lines = ['\n'] + termite_config.readlines()
         with open(termite_pywal_cache, 'a') as termite_colors:
-            termite_colors.write('\n')
             termite_colors.writelines(termite_config_lines)
 
     logging.info("Exported all files.")

--- a/pywal/export.py
+++ b/pywal/export.py
@@ -38,6 +38,7 @@ def get_export_type(export_type):
         "json": "colors.json",
         "konsole": "colors-konsole.colorscheme",
         "kitty": "colors-kitty.conf",
+        "termite": "colors-termite.conf",
         "plain": "colors",
         "putty": "colors-putty.reg",
         "rofi": "colors-rofi.Xresources",

--- a/pywal/export.py
+++ b/pywal/export.py
@@ -76,11 +76,11 @@ def every(colors, output_dir=CACHE_DIR):
     termite_pywal_config = join(HOME, '.config/termite/termite-pywal.conf')
     if os.path.isfile(termite_pywal_config):
         termite_pywal_cache = os.path.join(CACHE_DIR, 'colors-termite.conf')
-        with open(termite_pywal_config, 'r') as not_color:
-            not_color_lines = not_color.readlines()
-        with open(termite_pywal_cache, 'a') as color:
-            color.write('\n')
-            color.writelines(not_color_lines)
+        with open(termite_pywal_config, 'r') as termite_config:
+            termite_config_lines = termite_config.readlines()
+        with open(termite_pywal_cache, 'a') as termite_colors:
+            termite_colors.write('\n')
+            termite_colors.writelines(termite_config_lines)
 
     logging.info("Exported all files.")
     logging.info("Exported all user files.")

--- a/pywal/templates/colors-termite.conf
+++ b/pywal/templates/colors-termite.conf
@@ -2,7 +2,7 @@
 foreground = {foreground}
 background = {background}
 cursor     = {cursor}
-           =
+
 color0     = {color0}
 color8     = {color8}
 color1     = {color1}

--- a/pywal/templates/colors-termite.conf
+++ b/pywal/templates/colors-termite.conf
@@ -1,0 +1,21 @@
+[colors]
+foreground = {foreground}
+background = {background}
+cursor     = {cursor}
+           =
+color0     = {color0}
+color8     = {color8}
+color1     = {color1}
+color9     = {color9}
+color2     = {color2}
+color10    = {color10}
+color3     = {color3}
+color11    = {color11}
+color4     = {color4}
+color12    = {color12}
+color5     = {color5}
+color13    = {color13}
+color6     = {color6}
+color14    = {color14}
+color7     = {color7}
+color15    = {color15}


### PR DESCRIPTION
Doing this again as I merged to master beforehand, I didn't know that was a mistake.

1. Added termite template
2. Automatically append user's additional config to it so he can ln -s straight to the cached file
3. If the maintainer is fine with it, I would also like to add $XDG_CONFIG_HOME to pywal's config to make it more flexible than hardcoding "~/.config", but I did not do so for now in case this is not wanted.