### PR TITLE
export: add speedcrunch template

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -43,6 +43,7 @@ def get_export_type(export_type):
         "rofi": "colors-rofi.Xresources",
         "scss": "colors.scss",
         "shell": "colors.sh",
+        "speedcrunch": "colors-speedcrunch.json",
         "sway": "colors-sway",
         "tty": "colors-tty.sh",
         "xresources": "colors.Xresources",

--- a/pywal/templates/colors-speedcrunch.json
+++ b/pywal/templates/colors-speedcrunch.json
@@ -1,0 +1,15 @@
+{{
+    "cursor": "{cursor}",
+    "number": "{foreground}",
+    "parens": "{color13}",
+    "result": "{color12}",
+    "comment": "{color8}",
+    "matched": "{color4}",
+    "function": "{color1}",
+    "operator": "{color3}",
+    "variable": "{color2}",
+    "scrollbar": "{color3}",
+    "separator": "{color3}",
+    "background": "{background}",
+    "editorbackground": "{background}"
+}}


### PR DESCRIPTION
**SpeedCrunch** is a high-precision scientific calculator featuring a fast, keyboard-driven user interface. It is free and open-source software, licensed under the GPL.

```bash
mkdir -p ~/.local/share/SpeedCrunch/color-schemes
ln -sf ~/.cache/wal/colors-speedcrunch.json ~/.local/share/SpeedCrunch/color-schemes/wal.json
```
![2018-11-26-020540_618x371_scrot](https://user-images.githubusercontent.com/852504/49000735-2104a480-f120-11e8-9738-ccb618947993.png)
