### PR TITLE
Add support for #270:  Recursive -i argument

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -165,7 +165,7 @@ def parse_args(parser):
 
     if args.i:
         image_file = image.get(args.i, iterative=args.iterative,
-                                recursive=args.recursive)
+                               recursive=args.recursive)
         colors_plain = colors.get(image_file, args.l, args.backend,
                                   sat=args.saturate)
 

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -165,7 +165,7 @@ def parse_args(parser):
 
     if args.i:
         image_file = image.get(args.i, iterative=args.iterative,
-                recursive=args.recursive)
+              recursive=args.recursive)
         colors_plain = colors.get(image_file, args.l, args.backend,
                                   sat=args.saturate)
 

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -53,6 +53,11 @@ def get_args():
                           "flag is used: Go through the images in order "
                           "instead of shuffled.")
 
+    arg.add_argument("--recursive", action="store_true",
+                     help="When pywal is given a directory as input and this "
+                          "flag is used: Search for images recursively in "
+                          "subdirectories instead of the root only.")
+
     arg.add_argument("--saturate", metavar="0.0-1.0",
                      help="Set the color saturation.")
 
@@ -159,7 +164,8 @@ def parse_args(parser):
         util.Color.alpha_num = args.a
 
     if args.i:
-        image_file = image.get(args.i, iterative=args.iterative)
+        image_file = image.get(args.i, iterative=args.iterative,
+                recursive=args.recursive)
         colors_plain = colors.get(image_file, args.l, args.backend,
                                   sat=args.saturate)
 

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -165,7 +165,7 @@ def parse_args(parser):
 
     if args.i:
         image_file = image.get(args.i, iterative=args.iterative,
-              recursive=args.recursive)
+                                recursive=args.recursive)
         colors_plain = colors.get(image_file, args.l, args.backend,
                                   sat=args.saturate)
 

--- a/pywal/image.py
+++ b/pywal/image.py
@@ -12,6 +12,22 @@ from . import util
 from . import wallpaper
 
 
+def get_image_dir_recursive(img_dir):
+    """Get all images in a directory recursively."""
+    current_wall = wallpaper.get()
+    current_wall = os.path.basename(current_wall)
+
+    file_types = (".png", ".jpg", ".jpeg", ".jpe", ".gif")
+
+    images = []
+    for path, subdirs, files in os.walk(img_dir):
+        for name in files:
+            print(os.path.join(path, name))
+            images.append(os.path.join(path, name))
+
+    return images, current_wall
+
+
 def get_image_dir(img_dir):
     """Get all images in a directory."""
     current_wall = wallpaper.get()
@@ -31,14 +47,27 @@ def get_random_image(img_dir):
         images.remove(current_wall)
 
     elif not images:
-        logging.error("No images found in directory, picking random directory.")
-        logging.info("Found dirs: {}".format([dir_file.name for dir_file in
-            os.scandir(img_dir)]))
-
+        logging.error("No images found in directory.")
         sys.exit(1)
 
     random.shuffle(images)
     return os.path.join(img_dir, images[0])
+
+
+def get_random_image_recursive(img_dir):
+    """Pick a random image file from a directory recursively."""
+    images, current_wall = get_image_dir_recursive(img_dir)
+
+    if len(images) > 2 and current_wall in images:
+        images.remove(current_wall)
+
+    elif not images:
+        logging.error("No images found in directory.")
+        sys.exit(1)
+
+    print(images)
+    random.shuffle(images)
+    return os.path.join("", images[0])
 
 
 def get_next_image(img_dir):
@@ -64,6 +93,7 @@ def get_next_image(img_dir):
 
 def get(img, cache_dir=CACHE_DIR, iterative=False, recursive=False):
     """Validate image input."""
+    recursive = True # TODO: Remove
     if os.path.isfile(img):
         wal_img = img
 
@@ -72,7 +102,10 @@ def get(img, cache_dir=CACHE_DIR, iterative=False, recursive=False):
             wal_img = get_next_image(img)
 
         else:
-            wal_img = get_random_image(img)
+            if recursive:
+                wal_img = get_random_image_recursive(img)
+            else:
+                wal_img = get_random_image(img)
 
     else:
         logging.error("No valid image file found.")

--- a/pywal/image.py
+++ b/pywal/image.py
@@ -22,8 +22,8 @@ def get_image_dir_recursive(img_dir):
     images = []
     for path, subdirs, files in os.walk(img_dir):
         for name in files:
-            print(os.path.join(path, name))
-            images.append(os.path.join(path, name))
+            if name.lower().endswith(file_types):
+              images.append(os.path.join(path, name))
 
     return images, current_wall
 

--- a/pywal/image.py
+++ b/pywal/image.py
@@ -41,9 +41,12 @@ def get_image_dir(img_dir):
             if img.name.lower().endswith(file_types)], current_wall
 
 
-def get_random_image(img_dir):
+def get_random_image(img_dir, recursive):
     """Pick a random image file from a directory."""
-    images, current_wall = get_image_dir(img_dir)
+    if recursive:
+        images, current_wall = get_image_dir_recursive(img_dir)
+    else:
+        images, current_wall = get_image_dir(img_dir)
 
     if len(images) > 2 and current_wall in images:
         images.remove(current_wall)
@@ -53,22 +56,7 @@ def get_random_image(img_dir):
         sys.exit(1)
 
     random.shuffle(images)
-    return os.path.join(img_dir, images[0])
-
-
-def get_random_image_recursive(img_dir):
-    """Pick a random image file from a directory recursively."""
-    images, current_wall = get_image_dir_recursive(img_dir)
-
-    if len(images) > 2 and current_wall in images:
-        images.remove(current_wall)
-
-    if not images:
-        logging.error("No images found in directory.")
-        sys.exit(1)
-
-    random.shuffle(images)
-    return os.path.join("", images[0])
+    return os.path.join(img_dir if not recursive else "", images[0])
 
 
 def get_next_image(img_dir, recursive):
@@ -106,10 +94,7 @@ def get(img, cache_dir=CACHE_DIR, iterative=False, recursive=False):
             wal_img = get_next_image(img, recursive)
 
         else:
-            if recursive:
-                wal_img = get_random_image_recursive(img)
-            else:
-                wal_img = get_random_image(img)
+            wal_img = get_random_image(img, recursive)
 
     else:
         logging.error("No valid image file found.")

--- a/pywal/image.py
+++ b/pywal/image.py
@@ -31,7 +31,10 @@ def get_random_image(img_dir):
         images.remove(current_wall)
 
     elif not images:
-        logging.error("No images found in directory.")
+        logging.error("No images found in directory, picking random directory.")
+        logging.info("Found dirs: {}".format([dir_file.name for dir_file in
+            os.scandir(img_dir)]))
+
         sys.exit(1)
 
     random.shuffle(images)
@@ -59,7 +62,7 @@ def get_next_image(img_dir):
     return os.path.join(img_dir, image)
 
 
-def get(img, cache_dir=CACHE_DIR, iterative=False):
+def get(img, cache_dir=CACHE_DIR, iterative=False, recursive=False):
     """Validate image input."""
     if os.path.isfile(img):
         wal_img = img

--- a/pywal/image.py
+++ b/pywal/image.py
@@ -20,7 +20,7 @@ def get_image_dir_recursive(img_dir):
     file_types = (".png", ".jpg", ".jpeg", ".jpe", ".gif")
 
     images = []
-    for path, subdirs, files in os.walk(img_dir):
+    for path, _, files in os.walk(img_dir):
         for name in files:
             if name.lower().endswith(file_types):
                 if name.endswith(current_wall):

--- a/pywal/image.py
+++ b/pywal/image.py
@@ -22,9 +22,10 @@ def get_image_dir_recursive(img_dir):
     images = []
     for path, subdirs, files in os.walk(img_dir):
         for name in files:
-            if name.lower().endswith(file_types) and not name.endswith(current_wall):
-              images.append(os.path.join(path, name))
-
+            if name.lower().endswith(file_types):
+                if name.endswith(current_wall):
+                    current_wall = os.path.join(path, name)
+                images.append(os.path.join(path, name))
 
     return images, current_wall
 
@@ -59,18 +60,24 @@ def get_random_image_recursive(img_dir):
     """Pick a random image file from a directory recursively."""
     images, current_wall = get_image_dir_recursive(img_dir)
 
+    if len(images) > 2 and current_wall in images:
+        images.remove(current_wall)
+
     if not images:
         logging.error("No images found in directory.")
         sys.exit(1)
 
-    print(images)
     random.shuffle(images)
     return os.path.join("", images[0])
 
 
-def get_next_image(img_dir):
+def get_next_image(img_dir, recursive):
     """Get the next image in a dir."""
-    images, current_wall = get_image_dir(img_dir)
+    if recursive:
+        images, current_wall = get_image_dir_recursive(img_dir)
+    else:
+        images, current_wall = get_image_dir(img_dir)
+
     images.sort(key=lambda img: [int(x) if x.isdigit() else x
                                  for x in re.split('([0-9]+)', img)])
 
@@ -86,7 +93,7 @@ def get_next_image(img_dir):
     except IndexError:
         image = images[0]
 
-    return os.path.join(img_dir, image)
+    return os.path.join(img_dir if not recursive else "", image)
 
 
 def get(img, cache_dir=CACHE_DIR, iterative=False, recursive=False):
@@ -97,7 +104,7 @@ def get(img, cache_dir=CACHE_DIR, iterative=False, recursive=False):
 
     elif os.path.isdir(img):
         if iterative:
-            wal_img = get_next_image(img)
+            wal_img = get_next_image(img, recursive)
 
         else:
             if recursive:

--- a/pywal/image.py
+++ b/pywal/image.py
@@ -98,7 +98,6 @@ def get_next_image(img_dir, recursive):
 
 def get(img, cache_dir=CACHE_DIR, iterative=False, recursive=False):
     """Validate image input."""
-    recursive = True # TODO: Remove
     if os.path.isfile(img):
         wal_img = img
 

--- a/pywal/image.py
+++ b/pywal/image.py
@@ -22,8 +22,9 @@ def get_image_dir_recursive(img_dir):
     images = []
     for path, subdirs, files in os.walk(img_dir):
         for name in files:
-            if name.lower().endswith(file_types):
+            if name.lower().endswith(file_types) and not name.endswith(current_wall):
               images.append(os.path.join(path, name))
+
 
     return images, current_wall
 
@@ -58,10 +59,7 @@ def get_random_image_recursive(img_dir):
     """Pick a random image file from a directory recursively."""
     images, current_wall = get_image_dir_recursive(img_dir)
 
-    if len(images) > 2 and current_wall in images:
-        images.remove(current_wall)
-
-    elif not images:
+    if not images:
         logging.error("No images found in directory.")
         sys.exit(1)
 


### PR DESCRIPTION
Fix https://github.com/dylanaraps/pywal/issues/270

* Add a new optional command line argument: `--recursive`, to use with `-i`
* Uses all images from subdirectories
* Works with random and iterative method

I tested it with this structure:
```
test-dir
├── dir1
│   ├── dir11
│   │   └── img_dir11.jpg
│   └── img_dir1.jpg
├── dir2
│   ├── img_dir21.JPG
│   └── img_dir2.jpg
├── dir3
│   ├── img_dir3.jpg
│   └── wrong_file_type.sh
├── img_root1.jpg
└── img_root2.jpg
```

Let me know what you think!
<sup>Feel free to sqash the commits btw, I fought with Travis over the indentation of a single line.</sup>