### PR TITLE
Improved/Fixed kitty support

### DIFF
--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -57,10 +57,10 @@ def bspwm():
 def kitty():
     """ Reload kitty colors. """
     if (shutil.which("kitty")
-        and util.get_pid("kitty")
-        and os.getenv('TERM') == 'xterm-kitty'):
+            and util.get_pid("kitty")
+            and os.getenv('TERM') == 'xterm-kitty'):
         subprocess.call([
-            "kitty", "@", "set-colors", "--all", 
+            "kitty", "@", "set-colors", "--all",
             os.path.join(CACHE_DIR, "colors-kitty.conf")
         ])
 

--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -56,8 +56,13 @@ def bspwm():
 
 def kitty():
     """ Reload kitty colors. """
-    if shutil.which("kitty") and util.get_pid("kitty") and os.getenv('TERM') == 'xterm-kitty':
-        subprocess.call(["kitty", "@", "set-colors", "--all", os.path.join(CACHE_DIR, "colors-kitty.conf")])
+    if (shutil.which("kitty")
+        and util.get_pid("kitty")
+        and os.getenv('TERM') == 'xterm-kitty'):
+        subprocess.call([
+            "kitty", "@", "set-colors", "--all", 
+            os.path.join(CACHE_DIR, "colors-kitty.conf")
+        ])
 
 
 def polybar():

--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -56,8 +56,8 @@ def bspwm():
 
 def kitty():
     """ Reload kitty colors. """
-    if shutil.which("kitty") and util.get_pid("kitty"):
-        util.disown(["kitty", "@", "set-colors", "--all"])
+    if shutil.which("kitty") and util.get_pid("kitty") and os.getenv('TERM') == 'xterm-kitty':
+        subprocess.call(["kitty", "@", "set-colors", "--all", os.path.join(CACHE_DIR, "colors-kitty.conf")])
 
 
 def polybar():

--- a/pywal/templates/colors-kitty.conf
+++ b/pywal/templates/colors-kitty.conf
@@ -2,10 +2,10 @@ foreground   {foreground}
 background   {background}
 cursor       {cursor}
 
-active_tab_foreground     {foreground}
-active_tab_background     {background}
-inactive_tab_foreground   {background}
-inactive_tab_background   {foreground}
+active_tab_foreground     {background}
+active_tab_background     {foreground}
+inactive_tab_foreground   {foreground}
+inactive_tab_background   {background}
 
 active_border_color	{foreground}
 inactive_border_color	{background}

--- a/pywal/templates/colors-kitty.conf
+++ b/pywal/templates/colors-kitty.conf
@@ -7,6 +7,10 @@ active_tab_background     {background}
 inactive_tab_foreground   {background}
 inactive_tab_background   {foreground}
 
+active_border_color	{foreground}
+inactive_border_color	{background}
+bell_border_color	{color1}
+
 color0       {color0}
 color8       {color8}
 color1       {color1}

--- a/pywal/templates/colors-kitty.conf
+++ b/pywal/templates/colors-kitty.conf
@@ -2,6 +2,11 @@ foreground   {foreground}
 background   {background}
 cursor       {cursor}
 
+active_tab_foreground     {foreground}
+active_tab_background     {background}
+inactive_tab_foreground   {background}
+inactive_tab_background   {foreground}
+
 color0       {color0}
 color8       {color8}
 color1       {color1}


### PR DESCRIPTION
Pywal's method of updating kitty's colors does not work properly. 

The first issue is that changes would not happen due to `kitty @ *` not working from Python's `os.Popen`. This was solved by using `os.call`. Another issue arose from this fix - calling wal from a non-kitty terminal would hang and error out due to lack of access to `kitty` commands (this was also likely silently happening with `Popen`). The additional clause `and os.getenv('TERM') == 'xterm-kitty'` was added to correct for this. 

The second issue is that running `kitty @ set-colors --all` doesn't do anything without additional arguments. `os.path.join(CACHE_DIR, "colors-kitty.conf")` is passed to this kitty command to apply the new colors.

The third issue is that changes only take affect in the window wal is run in, due to kitty's remote control support - this is not an issue that can be solved with pywal; recommendations should be made to open kitty terminals with the commandline options `--single-instance` or `-1`, and with `allow_remote_control yes` in `kitty.conf`. These additional settings allow all kitty terminals to be synchronized, but there may be security implications.

This pull request also features an update to `colors-kitty.conf` which configures additional kitty colors.