### PR TITLE
Fixed pidof on Mac OS

### DIFF
--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -56,8 +56,8 @@ def bspwm():
 
 def kitty():
     """ Reload kitty colors. """
-    if shutil.which("kitty") and util.get_pid("kitty"):
-        util.disown(["kitty", "@", "set-colors", "--all"])
+    if shutil.which("kitty") and util.get_pid("kitty") and os.getenv('TERM') == 'xterm-kitty':
+        subprocess.call(["kitty", "@", "set-colors", "--all", os.path.join(CACHE_DIR, "colors-kitty.conf")])
 
 
 def polybar():

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import sys
+import platform
 
 
 class Color:
@@ -183,7 +184,10 @@ def get_pid(name):
         return False
 
     try:
-        subprocess.check_output(["pidof", "-s", name])
+        if platform.system() != 'Darwin':
+            subprocess.check_output(["pidof", "-s", name])
+        else:
+            subprocess.check_output(["pidof", name])
     except subprocess.CalledProcessError:
         return False
 


### PR DESCRIPTION
This is a fix that addresses #403 on Mac OS. This allows `pidof` to work even though `-s` doesn't exist.