### PR TITLE
Update link to travis build page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <p align="center">
 <a href="https://discord.gg/fK3RhsD"><img src="https://img.shields.io/discord/440354555197128704.svg"></a>
-<a href="https://travis-ci.org/dylanaraps/pywal"><img src="https://travis-ci.org/dylanaraps/pywal.svg?branch=master"></a>
+<a href="https://travis-ci.com/dylanaraps/pywal"><img src="https://api.travis-ci.com/dylanaraps/pywal.svg?branch=master"></a>
 <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 <a href="https://pypi.python.org/pypi/pywal/"><img src="https://img.shields.io/pypi/v/pywal.svg"></a>
 <a href="https://www.patreon.com/dyla"><img src="https://img.shields.io/badge/donate-patreon-yellow.svg"></a>


### PR DESCRIPTION
This project is currently building on travis-ci.com not on travis-ci.org as it used to. This will fix the broken link to the build along with the image representing the build state.

https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/