### PR TITLE
[Feature] Make wal -R understand the -l flag

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -179,14 +179,12 @@ def parse_args(parser):
         colors_plain = theme.file(os.path.join(CACHE_DIR, "colors.json"))
 
         if args.l:
-            wallpaper_cache = open(os.path.join(CACHE_DIR, "wal"))
-            cached_wallpaper = wallpaper_cache.read()
-            colors_plain = colors.get(cached_wallpaper, True, args.backend,
+            cached_wallpaper = util.read_file(os.path.join(CACHE_DIR, "wal"))
+            colors_plain = colors.get(cached_wallpaper[0], True, args.backend,
                                       sat=args.saturate)
         elif args.d:
-            wallpaper_cache = open(os.path.join(CACHE_DIR, "wal"))
-            cached_wallpaper = wallpaper_cache.read()
-            colors_plain = colors.get(cached_wallpaper, False, args.backend,
+            cached_wallpaper = util.read_file(os.path.join(CACHE_DIR, "wal"))
+            colors_plain = colors.get(cached_wallpaper[0], False, args.backend,
                                       sat=args.saturate)
 
     if args.b:

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -179,13 +179,13 @@ def parse_args(parser):
         colors_plain = theme.file(os.path.join(CACHE_DIR, "colors.json"))
 
         if args.l:
-            f = open(os.path.join(CACHE_DIR, "wal"))
-            cached_wallpaper = f.read()
+            wallpaper_cache = open(os.path.join(CACHE_DIR, "wal"))
+            cached_wallpaper = wallpaper_cache.read()
             colors_plain = colors.get(cached_wallpaper, True, args.backend,
                                       sat=args.saturate)
         elif args.d:
-            f = open(os.path.join(CACHE_DIR, "wal"))
-            cached_wallpaper = f.read()
+            wallpaper_cache = open(os.path.join(CACHE_DIR, "wal"))
+            cached_wallpaper = wallpaper_cache.read()
             colors_plain = colors.get(cached_wallpaper, False, args.backend,
                                       sat=args.saturate)
 

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -76,6 +76,9 @@ def get_args():
     arg.add_argument("-l", action="store_true",
                      help="Generate a light colorscheme.")
 
+    arg.add_argument("-d", action="store_true",
+                     help="Generate a dark colorscheme. Default.")
+
     arg.add_argument("-n", action="store_true",
                      help="Skip setting the wallpaper.")
 
@@ -174,6 +177,17 @@ def parse_args(parser):
 
     if args.R:
         colors_plain = theme.file(os.path.join(CACHE_DIR, "colors.json"))
+
+        if args.l:
+            f = open(os.path.join(CACHE_DIR, "wal"))
+            cached_wallpaper = f.read()
+            colors_plain = colors.get(cached_wallpaper, True, args.backend,
+                                      sat=args.saturate)
+        elif args.d:
+            f = open(os.path.join(CACHE_DIR, "wal"))
+            cached_wallpaper = f.read()
+            colors_plain = colors.get(cached_wallpaper, False, args.backend,
+                                      sat=args.saturate)
 
     if args.b:
         args.b = "#%s" % (args.b.strip("#"))


### PR DESCRIPTION
### Regarding: https://github.com/dylanaraps/pywal/issues/441

>It would be very nice to use `wal -R` to switch between the dark and the light version of a theme (from a picture)
>
>eg:
>`wal -R` restores the last theme
>`wal -R -l` gets a light theme from the image
>`wal -R -d` gets a dark theme from the image
>and if these were non image themes it could just switch to behave like `wal -R` without flags