### PR TITLE
[Feature] Use last used wallpaper for color generation

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -76,9 +76,6 @@ def get_args():
     arg.add_argument("-l", action="store_true",
                      help="Generate a light colorscheme.")
 
-    arg.add_argument("-d", action="store_true",
-                     help="Generate a dark colorscheme. Default.")
-
     arg.add_argument("-n", action="store_true",
                      help="Skip setting the wallpaper.")
 
@@ -103,6 +100,9 @@ def get_args():
 
     arg.add_argument("-v", action="store_true",
                      help="Print \"wal\" version.")
+
+    arg.add_argument("-w", action="store_true",
+                     help="Use last used wallpaper for color generation.")
 
     arg.add_argument("-e", action="store_true",
                      help="Skip reloading gtk/xrdb/i3/sway/polybar")
@@ -141,6 +141,7 @@ def parse_args_exit(parser):
     if not args.i and \
        not args.theme and \
        not args.R and \
+       not args.w and \
        not args.backend:
         parser.error("No input specified.\n"
                      "--backend, --theme, -i or -R are required.")
@@ -178,14 +179,10 @@ def parse_args(parser):
     if args.R:
         colors_plain = theme.file(os.path.join(CACHE_DIR, "colors.json"))
 
-        if args.l:
-            cached_wallpaper = util.read_file(os.path.join(CACHE_DIR, "wal"))
-            colors_plain = colors.get(cached_wallpaper[0], True, args.backend,
-                                      sat=args.saturate)
-        elif args.d:
-            cached_wallpaper = util.read_file(os.path.join(CACHE_DIR, "wal"))
-            colors_plain = colors.get(cached_wallpaper[0], False, args.backend,
-                                      sat=args.saturate)
+    if args.w:
+        cached_wallpaper = util.read_file(os.path.join(CACHE_DIR, "wal"))
+        colors_plain = colors.get(cached_wallpaper[0], args.l, args.backend,
+                                  sat=args.saturate)
 
     if args.b:
         args.b = "#%s" % (args.b.strip("#"))

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -179,14 +179,12 @@ def parse_args(parser):
         colors_plain = theme.file(os.path.join(CACHE_DIR, "colors.json"))
 
         if args.l:
-            wallpaper_cache = open(os.path.join(CACHE_DIR, "wal"))
-            cached_wallpaper = wallpaper_cache.read()
-            colors_plain = colors.get(cached_wallpaper, True, args.backend,
+            cached_wallpaper = util.read_file(os.path.join(CACHE_DIR, "wal"))
+            colors_plain = colors.get(cached_wallpaper[0], True, args.backend,
                                       sat=args.saturate)
         elif args.d:
-            wallpaper_cache = open(os.path.join(CACHE_DIR, "wal"))
-            cached_wallpaper = wallpaper_cache.read()
-            colors_plain = colors.get(cached_wallpaper, False, args.backend,
+            cached_wallpaper = util.read_file(os.path.join(CACHE_DIR, "wal"))
+            colors_plain = colors.get(cached_wallpaper[0], False, args.backend,
                                       sat=args.saturate)
 
     if args.b:

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -179,13 +179,13 @@ def parse_args(parser):
         colors_plain = theme.file(os.path.join(CACHE_DIR, "colors.json"))
 
         if args.l:
-            f = open(os.path.join(CACHE_DIR, "wal"))
-            cached_wallpaper = f.read()
+            wallpaper_cache = open(os.path.join(CACHE_DIR, "wal"))
+            cached_wallpaper = wallpaper_cache.read()
             colors_plain = colors.get(cached_wallpaper, True, args.backend,
                                       sat=args.saturate)
         elif args.d:
-            f = open(os.path.join(CACHE_DIR, "wal"))
-            cached_wallpaper = f.read()
+            wallpaper_cache = open(os.path.join(CACHE_DIR, "wal"))
+            cached_wallpaper = wallpaper_cache.read()
             colors_plain = colors.get(cached_wallpaper, False, args.backend,
                                       sat=args.saturate)
 

--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -76,6 +76,9 @@ def get_args():
     arg.add_argument("-l", action="store_true",
                      help="Generate a light colorscheme.")
 
+    arg.add_argument("-d", action="store_true",
+                     help="Generate a dark colorscheme. Default.")
+
     arg.add_argument("-n", action="store_true",
                      help="Skip setting the wallpaper.")
 
@@ -174,6 +177,17 @@ def parse_args(parser):
 
     if args.R:
         colors_plain = theme.file(os.path.join(CACHE_DIR, "colors.json"))
+
+        if args.l:
+            f = open(os.path.join(CACHE_DIR, "wal"))
+            cached_wallpaper = f.read()
+            colors_plain = colors.get(cached_wallpaper, True, args.backend,
+                                      sat=args.saturate)
+        elif args.d:
+            f = open(os.path.join(CACHE_DIR, "wal"))
+            cached_wallpaper = f.read()
+            colors_plain = colors.get(cached_wallpaper, False, args.backend,
+                                      sat=args.saturate)
 
     if args.b:
         args.b = "#%s" % (args.b.strip("#"))


### PR DESCRIPTION
Alternative of https://github.com/dylanaraps/pywal/pull/450 as discussed: https://github.com/dylanaraps/pywal/pull/450#issuecomment-530261257.

Now you can use `-w` to use the last used wallpaper, and combine it with `-l` to generate a light theme from it. It's a separate flag from `-R`.

Please see if this is better @dylanaraps & @927589452 than the original way.