### PR TITLE
[Enhancement] #305: Add indication next to previous theme when running wal --theme

### DIFF
--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -6,7 +6,7 @@ import os
 import random
 import sys
 
-from .settings import CONF_DIR, MODULE_DIR
+from .settings import CACHE_DIR, CONF_DIR, MODULE_DIR
 from . import util
 
 
@@ -116,6 +116,7 @@ def file(input_file, light=False):
     if os.path.isfile(theme_file):
         logging.info("Set theme to \033[1;37m%s\033[0m.",
                      os.path.basename(theme_file))
+        util.save_file(os.path.basename(theme_file), os.path.join(CACHE_DIR, "theme"))
         return parse(theme_file)
 
     logging.error("No %s colorscheme file found.", bri)

--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -19,12 +19,16 @@ def list_out():
     user_themes = [theme.name.replace(".json", "")
                    for theme in list_themes_user()]
 
+    last_used_theme = util.read_file(os.path.join(CACHE_DIR,
+        "last_used_theme"))[0].replace(".json", "")
+
     if user_themes:
         print("\033[1;32mUser Themes\033[0m:")
         print(" -", "\n - ".join(sorted(user_themes)))
 
     print("\033[1;32mDark Themes\033[0m:")
     print(" -", "\n - ".join(sorted(dark_themes)))
+    print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t for t in sorted(dark_themes)))
 
     print("\033[1;32mLight Themes\033[0m:")
     print(" -", "\n - ".join(sorted(ligh_themes)))
@@ -116,7 +120,8 @@ def file(input_file, light=False):
     if os.path.isfile(theme_file):
         logging.info("Set theme to \033[1;37m%s\033[0m.",
                      os.path.basename(theme_file))
-        util.save_file(os.path.basename(theme_file), os.path.join(CACHE_DIR, "theme"))
+        util.save_file(os.path.basename(theme_file), os.path.join(CACHE_DIR,
+            "last_used_theme"))
         return parse(theme_file)
 
     logging.error("No %s colorscheme file found.", bri)

--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -19,14 +19,13 @@ def list_out():
     user_themes = [theme.name.replace(".json", "")
                    for theme in list_themes_user()]
 
-
     last_used_theme = util.read_file(os.path.join(
         CACHE_DIR, "last_used_theme"))[0].replace(".json", "")
 
     if user_themes:
         print("\033[1;32mUser Themes\033[0m:")
-        print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t
-                                 for t in sorted(user_themes)))
+        print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme
+                                 else t for t in sorted(user_themes)))
 
     print("\033[1;32mDark Themes\033[0m:")
     print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t

--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -19,21 +19,22 @@ def list_out():
     user_themes = [theme.name.replace(".json", "")
                    for theme in list_themes_user()]
 
-    last_used_theme = util.read_file(os.path.join(CACHE_DIR,
-        "last_used_theme"))[0].replace(".json", "")
+
+    last_used_theme = util.read_file(os.path.join(
+        CACHE_DIR, "last_used_theme"))[0].replace(".json", "")
 
     if user_themes:
         print("\033[1;32mUser Themes\033[0m:")
         print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t
-            for t in sorted(user_themes)))
+                                 for t in sorted(user_themes)))
 
     print("\033[1;32mDark Themes\033[0m:")
     print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t
-        for t in sorted(dark_themes)))
+                             for t in sorted(dark_themes)))
 
     print("\033[1;32mLight Themes\033[0m:")
     print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t
-        for t in sorted(ligh_themes)))
+                             for t in sorted(ligh_themes)))
 
     print("\033[1;32mExtra\033[0m:")
     print(" - random (select a random dark theme)")
@@ -122,8 +123,8 @@ def file(input_file, light=False):
     if os.path.isfile(theme_file):
         logging.info("Set theme to \033[1;37m%s\033[0m.",
                      os.path.basename(theme_file))
-        util.save_file(os.path.basename(theme_file), os.path.join(CACHE_DIR,
-            "last_used_theme"))
+        util.save_file(os.path.basename(theme_file),
+                       os.path.join(CACHE_DIR, "last_used_theme"))
         return parse(theme_file)
 
     logging.error("No %s colorscheme file found.", bri)

--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -24,14 +24,16 @@ def list_out():
 
     if user_themes:
         print("\033[1;32mUser Themes\033[0m:")
-        print(" -", "\n - ".join(sorted(user_themes)))
+        print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t
+            for t in sorted(user_themes)))
 
     print("\033[1;32mDark Themes\033[0m:")
-    print(" -", "\n - ".join(sorted(dark_themes)))
-    print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t for t in sorted(dark_themes)))
+    print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t
+        for t in sorted(dark_themes)))
 
     print("\033[1;32mLight Themes\033[0m:")
-    print(" -", "\n - ".join(sorted(ligh_themes)))
+    print(" -", "\n - ".join(t + " (last used)" if t == last_used_theme else t
+        for t in sorted(ligh_themes)))
 
     print("\033[1;32mExtra\033[0m:")
     print(" - random (select a random dark theme)")


### PR DESCRIPTION
### Regarding #305:
* Prints `(last used`) next to last used theme when listing themes with `--theme`.

I couldn't decide on a symbol to use, so I just used text. If @ghost or someone else has a suggestion, feel free to let me know.

-- 
Closes #305 