### PR TITLE
[Bug] Fix error if theme has never been set

### DIFF
--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -19,8 +19,11 @@ def list_out():
     user_themes = [theme.name.replace(".json", "")
                    for theme in list_themes_user()]
 
-    last_used_theme = util.read_file(os.path.join(
-        CACHE_DIR, "last_used_theme"))[0].replace(".json", "")
+    try:
+        last_used_theme = util.read_file(os.path.join(
+            CACHE_DIR, "last_used_theme"))[0].replace(".json", "")
+    except FileNotFoundError:
+        last_used_theme = ""
 
     if user_themes:
         print("\033[1;32mUser Themes\033[0m:")


### PR DESCRIPTION
Slight oversight on my part regarding #456:
* **Bug**: When the theme has never been set, retrieval of the previous theme threw an error (`FileNotFoundError`).
* **Fix**: Fixed it now by checking for the existence of the previous theme.

I realized it almost immediately after the MR was merged, but just got home now to push a fix, sorry about that.