### PR TITLE
fix template issue

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -25,7 +25,7 @@ def template(colors, input_file, output_file=None):
             # Color to be modified copied into new one
             new_color = util.Color(colors[cname].hex_color)
             # Execute each function to be done
-            for func in filter(None, funcs.split(")")):
+            for func in filter(None, re.split("\)|\.", funcs)):
                 # Get function name and arguments
                 func = func.split("(")
                 fname = func[0]
@@ -47,11 +47,18 @@ def template(colors, input_file, output_file=None):
                     if func[0] != '.':
                         replace_str += "."
                     replace_str += "(".join(func) + ")"
+                else:
+                    # if it is an attribute i.e. rgb
+                    replace_str += '.' + fname
+                    new_color = function
+
+            if not isinstance(new_color, str):
+                new_color = new_color.strip
             # If the color was changed, replace with a unique identifier.
             if new_color is not colors[cname]:
-                template_data[i] = l.replace(
-                    replace_str, "color" + new_color.strip)
-                colors["color" + new_color.strip] = new_color
+                new_color_clean = new_color.replace('[', '_').replace(']', '_')
+                template_data[i] = l.replace(replace_str, "color" + new_color_clean)
+                colors["color" + new_color_clean] = new_color
     try:
         template_data = "".join(template_data).format(**colors)
     except ValueError:

--- a/pywal/export.py
+++ b/pywal/export.py
@@ -12,6 +12,7 @@ from .settings import CACHE_DIR, CONF_DIR, MODULE_DIR
 def template(colors, input_file, output_file=None):
     """Read template file, substitute markers and
        save the file elsewhere."""
+    # pylint: disable-msg=too-many-locals
     template_data = util.read_file_raw(input_file)
     for i, l in enumerate(template_data):
         for match in re.finditer(r"(?<=(?<!\{))(\{([^{}]+)\})(?=(?!\}))", l):
@@ -25,7 +26,7 @@ def template(colors, input_file, output_file=None):
             # Color to be modified copied into new one
             new_color = util.Color(colors[cname].hex_color)
             # Execute each function to be done
-            for func in filter(None, re.split("\)|\.", funcs)):
+            for func in filter(None, re.split(r"\)|\.", funcs)):
                 # Get function name and arguments
                 func = func.split("(")
                 fname = func[0]
@@ -52,12 +53,13 @@ def template(colors, input_file, output_file=None):
                     replace_str += '.' + fname
                     new_color = function
 
-            if not isinstance(new_color, str):
+            if isinstance(new_color, util.Color):
                 new_color = new_color.strip
             # If the color was changed, replace with a unique identifier.
             if new_color is not colors[cname]:
                 new_color_clean = new_color.replace('[', '_').replace(']', '_')
-                template_data[i] = l.replace(replace_str, "color" + new_color_clean)
+                template_data[i] = l.replace(replace_str,
+                                             "color" + new_color_clean)
                 colors["color" + new_color_clean] = new_color
     try:
         template_data = "".join(template_data).format(**colors)


### PR DESCRIPTION
Hi,
I was having problems with the template system where strings not between brackets were being replaced. 
To reproduce this issue add the following template:
```
background = {background.rbg}
```
It creates a file with:
```
color0A0E1F =10,14,31 
```

I think this is due to the changes done to allow for calling `util.Color` methods from the template file. I fixed it for my use case however, I have not tested it thoroughly. 

I will leave this here, feel free to do whatever you want with it, and hopefully it might help someone out.