### PR TITLE
reload: revert to using subprocess.run to wait for each merge to finish

### DIFF
--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -26,7 +26,7 @@ def xrdb(xrdb_files=None):
 
     if shutil.which("xrdb") and OS != "Darwin":
         for file in xrdb_files:
-            subprocess.run(["xrdb", "-merge", "-quiet", file])
+            subprocess.run(["xrdb", "-merge", "-quiet", file], check=False)
 
 
 def gtk():

--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -26,7 +26,7 @@ def xrdb(xrdb_files=None):
 
     if shutil.which("xrdb") and OS != "Darwin":
         for file in xrdb_files:
-            subprocess.Popen(["xrdb", "-merge", "-quiet", file])
+            subprocess.run(["xrdb", "-merge", "-quiet", file])
 
 
 def gtk():


### PR DESCRIPTION
Reverts from using `Popen` to using `run` due to the reasons explained in issue #491 