### PR TITLE
alpha decimal support

### DIFF
--- a/pywal/templates/colors-kitty.conf
+++ b/pywal/templates/colors-kitty.conf
@@ -1,15 +1,16 @@
-foreground   {foreground}
-background   {background}
-cursor       {cursor}
+foreground         {foreground}
+background         {background}
+background_opacity {background.alpha_dec}
+cursor             {cursor}
 
 active_tab_foreground     {background}
 active_tab_background     {foreground}
 inactive_tab_foreground   {foreground}
 inactive_tab_background   {background}
 
-active_border_color	{foreground}
-inactive_border_color	{background}
-bell_border_color	{color1}
+active_border_color   {foreground}
+inactive_border_color {background}
+bell_border_color     {color1}
 
 color0       {color0}
 color8       {color8}

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -50,7 +50,7 @@ class Color:
     
     @property
     def octal(self):
-        """Export color in octal"""
+        """Export color in octal."""
         return "%s%s" % ("#", oct(int(self.hex_color[1:], 16))[2:])
 
     @property
@@ -79,17 +79,17 @@ class Color:
         return "%.3f" % (hex_to_rgb(self.hex_color)[2]/255.)
 
     def lighten(self, percent):
-        """Lighten color by percent"""
+        """Lighten color by percent."""
         percent = float(re.sub(r'[\D\.]', '', str(percent)))
         return Color(lighten_color(self.hex_color, percent / 100))
 
     def darken(self, percent):
-        """Darken color by percent"""
+        """Darken color by percent."""
         percent = float(re.sub(r'[\D\.]', '', str(percent)))
         return Color(darken_color(self.hex_color, percent / 100))
 
     def saturate(self, percent):
-        """Saturate a color"""
+        """Saturate a color."""
         percent = float(re.sub(r'[\D\.]', '', str(percent)))
         return Color(saturate_color(self.hex_color, percent / 100))
 
@@ -108,7 +108,7 @@ def read_file_json(input_file):
 
 def read_file_raw(input_file):
     """Read data from a file as is, don't strip
-       newlines or other special characters.."""
+       newlines or other special characters."""
     with open(input_file, "r") as file:
         return file.readlines()
 

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -45,6 +45,7 @@ class Color:
 
     @property
     def alpha_dec(self):
+        """Export the alpha value as a decimal number in [0, 1]."""
         return int(self.alpha_num) / 100
     
     @property

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -47,7 +47,7 @@ class Color:
     def alpha_dec(self):
         """Export the alpha value as a decimal number in [0, 1]."""
         return int(self.alpha_num) / 100
-    
+
     @property
     def octal(self):
         """Export color in octal."""

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -36,13 +36,17 @@ class Color:
     def rgba(self):
         """Convert a hex color to rgba."""
         return "rgba(%s,%s,%s,%s)" % (*hex_to_rgb(self.hex_color),
-                                      int(self.alpha_num) / 100)
+                                      self.alpha_dec)
 
     @property
     def alpha(self):
         """Add URxvt alpha value to color."""
         return "[%s]%s" % (self.alpha_num, self.hex_color)
 
+    @property
+    def alpha_dec(self):
+        return int(self.alpha_num) / 100
+    
     @property
     def octal(self):
         """Export color in octal"""


### PR DESCRIPTION
`kitty` expects its [background opacity](https://sw.kovidgoyal.net/kitty/conf.html#opt-kitty.background_opacity) to be defined as a decimal. This is currently not supported.

This PR adds support for this, but depends on #485 or #496. I updated the default kitty template file. I suggest to edit the wiki as well.