### PR TITLE
Fix error with iterative option in empty directory

### DIFF
--- a/pywal/image.py
+++ b/pywal/image.py
@@ -79,7 +79,11 @@ def get_next_image(img_dir, recursive):
         image = images[next_index]
 
     except IndexError:
-        image = images[0]
+        if images:
+            image = images[0]
+        else:
+            logging.error("No images found in directory.")
+            sys.exit(1)
 
     return os.path.join(img_dir if not recursive else "", image)
 


### PR DESCRIPTION
Pywal would crash when run in an empty directory with the iterative option, .e.g.:
```bash
wal -i <empty directory> --iterative
```
This pr fixes this and just prints `No images found in directory` instead.