### PR TITLE
Fix for kitty alpha_dec replacer

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -57,14 +57,15 @@ def template(colors, input_file, output_file=None):
                 new_color = new_color.strip
             # If the color was changed, replace with a unique identifier.
             if new_color is not colors[cname]:
-                new_color_clean = new_color.replace('[', '_').replace(']', '_')
+                new_color = str(new_color)
+                new_color_clean = new_color.replace('[', '_').replace(']', '_').replace('.', '_')
                 template_data[i] = l.replace(replace_str,
                                              "color" + new_color_clean)
                 colors["color" + new_color_clean] = new_color
     try:
         template_data = "".join(template_data).format(**colors)
-    except ValueError:
-        logging.error("Syntax error in template file '%s'.", input_file)
+    except (ValueError, KeyError, AttributeError) as exc:
+        logging.error("Syntax error in template file '%s': %r.", input_file, exc)
         return
     util.save_file(template_data, output_file)
 


### PR DESCRIPTION
This should have probably been `re.sub` (with a callable replacer) instead of `re.finditer` + `l.replace`, by the way.

Template-side counterpart: https://github.com/dylanaraps/pywal/blob/eb4200820b13006e2434bbc0bb402ed89726d042/pywal/templates/colors-kitty.conf#L3

Relevant: #525