### PR TITLE
Fix alpha when set from a .json

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -77,6 +77,7 @@ def flatten_colors(colors):
                   "alpha": colors["alpha"],
                   **colors["special"],
                   **colors["colors"]}
+    util.Color.alpha_num = all_colors["alpha"]
     return {k: util.Color(v) for k, v in all_colors.items()}
 
 

--- a/pywal/theme.py
+++ b/pywal/theme.py
@@ -82,7 +82,7 @@ def parse(theme_file):
         data["wallpaper"] = "None"
 
     if "alpha" not in data:
-        data["alpha"] = util.Color.alpha_num
+        data["alpha"] = "100"
 
     # Terminal.sexy format.
     if "color" in data:

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -14,6 +14,7 @@ import sys
 
 class Color:
     """Color formats."""
+    alpha_num = "100"
 
     def __init__(self, hex_color):
         self.hex_color = hex_color

--- a/pywal/util.py
+++ b/pywal/util.py
@@ -14,7 +14,6 @@ import sys
 
 class Color:
     """Color formats."""
-    alpha_num = "100"
 
     def __init__(self, hex_color):
         self.hex_color = hex_color


### PR DESCRIPTION
**When trying to set a color scheme using `pywal` as a module, such as in[ this example](https://github.com/dylanaraps/pywal/wiki/Using-%60pywal%60-as-a-module#example-showing-colors-read-from-json-file), alpha was not being correctly exported.** In .Xresources, for instance, URxvt*background would be set with [100]#rrggbb. This pull request fixes this behavior by:

Specifying a default value for the cases when alpha is not in data:
pywal/theme.py 
``` python
if "alpha" not in data:
    data["alpha"] = "100"
```
and setting util.Color.alpha_num from data:
pywal/export.py
``` python
util.Color.alpha_num = all_colors["alpha"]
```
**Therefore, it is not necessary to set it as "100" in the class Color definition.**
These changes can be appreciated in their context in the diff.

Open to implement further changes if I am missing something.
Thank you.