### PR TITLE
Add gtk3 theme reloading

### DIFF
--- a/pywal/__main__.py
+++ b/pywal/__main__.py
@@ -112,6 +112,9 @@ def get_args():
     arg.add_argument("-e", action="store_true",
                      help="Skip reloading gtk/xrdb/i3/sway/polybar")
 
+    arg.add_argument("-g", action="store_true",
+                     help="Reload the gtk3 theme")
+
     return arg
 
 
@@ -216,6 +219,9 @@ def parse_args(parser):
 
     if not args.e:
         reload.gtk()
+    
+    if args.g:
+        reload.gtk3()
 
 
 def main():


### PR DESCRIPTION
This code is copied from the https://github.com/deviantfero/wpgtk repo, I thought it would be useful to move the gtk3 reloading code into the upstream wal, instead of having a custom solution.

This requires a theme like deviantfero's FlatColor to change gtk3 color theme
on reload. To test, download this folder https://github.com/deviantfero/wpgtk-templates/tree/master/FlatColor into ~/.themes. Add the base files to the user template folder, and symlink the ~/.cache/wal/*/gtk*.base to the non-base files in the theme directory. Use the -g command line parameter to use this function.

I tested this function and it works just like you would expect.