### PR TITLE
Add support for ARGB hex strings

### DIFF
--- a/pywal/util.py
+++ b/pywal/util.py
@@ -39,6 +39,12 @@ class Color:
                                       self.alpha_dec)
 
     @property
+    def hex_argb(self):
+        """Convert an alpha hex color to argb hex."""
+        return "#%02X%s" % (int(int(self.alpha_num) * 255 / 100),
+                            self.hex_color[1:])
+
+    @property
     def alpha(self):
         """Add URxvt alpha value to color."""
         return "[%s]%s" % (self.alpha_num, self.hex_color)


### PR DESCRIPTION
Polybar only supports `#ARGB` for transparency. I previously used the workaround in https://github.com/dylanaraps/pywal/issues/132#issuecomment-352296339, however this is not a particularly clean solution.

With this change I can simply import 

`~/.cache/wal/colors-polybar.ini` and have the `#ARGB` pre-defined with no need to pass in the color via an environment variable 