### PR TITLE
Pass socket as an argument if reloading kitty from outside

### DIFF
--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -57,12 +57,17 @@ def bspwm():
 def kitty():
     """ Reload kitty colors. """
     if (shutil.which("kitty")
-            and util.get_pid("kitty")
-            and os.getenv('TERM') == 'xterm-kitty'):
-        subprocess.call([
-            "kitty", "@", "set-colors", "--all",
-            os.path.join(CACHE_DIR, "colors-kitty.conf")
-        ])
+            and util.get_pid("kitty")):
+        if os.getenv('TERM') == 'xterm-kitty':
+            subprocess.call([
+                "kitty", "@", "set-colors", "--all",
+                os.path.join(CACHE_DIR, "colors-kitty.conf")
+            ])
+        else:
+            subprocess.call([
+                "kitty", "@", "--to", "unix:/tmp/kitty_pywal", "set-colors", "--all",
+                os.path.join(CACHE_DIR, "colors-kitty.conf")
+            ])
 
 
 def polybar():


### PR DESCRIPTION
By default kitty remote control only works if invoked from within one of the kitty processes. Which is not the case when the driver process running pywal is an independent daemon or another program. In those cases, we need to specify the socket that kitty listens on for remote commands.