### PR TITLE
Updated templates to be compatible with rofi 1.7.0^

### DIFF
--- a/pywal/templates/colors-rofi-dark.rasi
+++ b/pywal/templates/colors-rofi-dark.rasi
@@ -73,6 +73,11 @@
     padding: 1px;
 }}
 
+#element-text, element-icon {{
+    background-color: inherit;
+    text-color:       inherit;
+}}
+
 #element.normal.normal {{
     background-color: @normal-background;
     text-color: @normal-foreground;

--- a/pywal/templates/colors-rofi-light.rasi
+++ b/pywal/templates/colors-rofi-light.rasi
@@ -73,6 +73,11 @@
     padding: 1px;
 }}
 
+#element-text, element-icon {{
+    background-color: inherit;
+    text-color:       inherit;
+}}
+
 #element.normal.normal {{
     background-color: @normal-background;
     text-color: @normal-foreground;


### PR DESCRIPTION
New version of Rofi has certain issues with old themes, particularly with font and background colors. Updated templates accordingly.

See
https://github.com/davatorium/rofi/issues/1397
https://github.com/davatorium/rofi/releases/tag/1.7.0