### PR TITLE
Reload tty when TERM is set to linux-16color

### DIFF
--- a/pywal/reload.py
+++ b/pywal/reload.py
@@ -15,7 +15,7 @@ def tty(tty_reload):
     tty_script = os.path.join(CACHE_DIR, "colors-tty.sh")
     term = os.environ.get("TERM")
 
-    if tty_reload and term == "linux":
+    if tty_reload and (term == "linux" or term == "linux-16color"):
         subprocess.Popen(["sh", tty_script])
 
 

--- a/pywal/templates/colors-tty.sh
+++ b/pywal/templates/colors-tty.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-[ "${{TERM:-none}}" = "linux" ] && \
+if [ "${{TERM:-none}}" = "linux" ] || [ "${{TERM:-none}}" = "linux-16color" ]; then
     printf '%b' '\e]P0{color0.strip}
                  \e]P1{color1.strip}
                  \e]P2{color2.strip}
@@ -17,3 +17,4 @@
                  \e]PE{color14.strip}
                  \e]PF{color15.strip}
                  \ec'
+fi


### PR DESCRIPTION
I prefer to set TERM=linux-16color in my tty sessions.  This enables the use of 16 unique colors (not just the usual 8 with their bright/dim variations).  Among other things, this allows vim to use all 16 colors as background colors in a tty.