### PR TITLE
sequences: fix terminal bold color

### DIFF
--- a/pywal/sequences.py
+++ b/pywal/sequences.py
@@ -46,7 +46,8 @@ def create_sequences(colors, vte_fix=False):
     # Special colors.
     # Source: https://goo.gl/KcoQgP
     # 10 = foreground, 11 = background, 12 = cursor foreground
-    # 13 = mouse foreground, 708 = background border color.
+    # 13 = mouse foreground, 708 = background border color,
+    # 706 = bold color.
     sequences.extend([
         set_special(10, colors["special"]["foreground"], "g"),
         set_special(11, colors["special"]["background"], "h", alpha),
@@ -54,6 +55,7 @@ def create_sequences(colors, vte_fix=False):
         set_special(13, colors["special"]["foreground"], "j"),
         set_special(17, colors["special"]["foreground"], "k"),
         set_special(19, colors["special"]["background"], "m"),
+        set_special(706, colors["special"]["foreground"], "i"),
         set_color(232, colors["special"]["background"]),
         set_color(256, colors["special"]["foreground"]),
         set_color(257, colors["special"]["background"]),


### PR DESCRIPTION
These changes set the bold color on terminals to the foreground color.

This fixes a pywal bug on iTerm in macOS: when using a light color theme, foreground-coloured bold characters are displayed with the background color, thus "invisible" (for example, run `man man`)

For other terminals this change shouldn't make a difference.

Notes:
    "Coloured" bold colours are unaffected by this change
    I tested these changes on macOS with iTerm and on Void Linux with Alacritty

Reference:
    https://iterm2.com/3.3/documentation-escape-codes.html
    http://pod.tst.eu/http://cvs.schmorp.de/rxvt-unicode/doc/rxvt.7.pod#XTerm_Operating_System_Commands

Screenshots:

"Invisible" bold colours:
![Screenshot 2021-11-20 at 16 11 33](https://user-images.githubusercontent.com/21295306/142733341-d43af68c-f310-48e0-9222-5f810edd0eb0.png)

Fixed bold colors:
![Screenshot 2021-11-20 at 16 02 58](https://user-images.githubusercontent.com/21295306/142733078-49356db6-dc06-42d3-9e0c-663640a2a671.png)

Other working unchanged coloured bold colours:
![Screenshot 2021-11-20 at 16 06 51](https://user-images.githubusercontent.com/21295306/142733136-3c70d1d3-29e5-4155-adb4-b0ec32ff49b6.png)

