### PR TITLE
Fix for crash when ~/.cache/wal was empty

### DIFF
--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -202,6 +202,10 @@ def get(cache_dir=CACHE_DIR):
     current_wall = os.path.join(cache_dir, "wal")
 
     if os.path.isfile(current_wall):
-        return util.read_file(current_wall)[0]
+        # make sure the file has some content in it,
+        contents = util.read_file(current_wall)
+        
+        if len(contents) > 0:
+            return contents [0]
 
     return "None"


### PR DESCRIPTION
I don't know exactly what caused it, but the ~/.cache/wal file was created AND empty, so pywal crashed every time it tried to set a new wallpaper and took me some time to realize what was happening. This PR should fix it.