### PR TITLE
Adding support for gnome dark mode wallpapers

### DIFF
--- a/pywal/wallpaper.py
+++ b/pywal/wallpaper.py
@@ -103,7 +103,10 @@ def set_desktop_wallpaper(desktop, img):
     elif "gnome" in desktop or "unity" in desktop:
         util.disown(["gsettings", "set",
                      "org.gnome.desktop.background",
-                     "picture-uri", "file://" + urllib.parse.quote(img)])
+                     "picture-uri-dark", "file://" + urllib.parse.quote(img)])
+        util.disown(["gsettings", "set",
+                      "org.gnome.desktop.background",
+                      "picture-uri", "file://" + urllib.parse.quote(img)])
 
     elif "mate" in desktop:
         util.disown(["gsettings", "set", "org.mate.background",


### PR DESCRIPTION
Credit goes to Vanadium for suggesting a fix on [AskUbuntu](https://askubuntu.com/questions/1403952/wallpaper-background-switches-back-to-default-when-in-dark-mode-22-04-lts).