### PR TITLE
Added rgb color template

### DIFF
--- a/pywal/templates/colors-rgb
+++ b/pywal/templates/colors-rgb
@@ -1,0 +1,16 @@
+{color0.rgb}
+{color1.rgb}
+{color2.rgb}
+{color3.rgb}
+{color4.rgb}
+{color5.rgb}
+{color6.rgb}
+{color7.rgb}
+{color8.rgb}
+{color9.rgb}
+{color10.rgb}
+{color11.rgb}
+{color12.rgb}
+{color13.rgb}
+{color14.rgb}
+{color15.rgb}


### PR DESCRIPTION
Dear maintainer,
When using pywal I found it lacked a version of the colors file with the colors in rgb format instead of hex format. So I took the initiative to add it! Love your project!
TheWisker