### PR TITLE
Check user template directory when exporting single template file in Python

### DIFF
--- a/pywal/export.py
+++ b/pywal/export.py
@@ -135,7 +135,12 @@ def color(colors, export_type, output_file=None):
     all_colors = flatten_colors(colors)
 
     template_name = get_export_type(export_type)
-    template_file = os.path.join(MODULE_DIR, "templates", template_name)
+
+    if template_name == export_type:
+        template_file = os.path.join(CONF_DIR, "templates", template_name)
+    else:
+        template_file = os.path.join(MODULE_DIR, "templates", template_name)
+
     output_file = output_file or os.path.join(CACHE_DIR, template_name)
 
     if os.path.isfile(template_file):


### PR DESCRIPTION
When using Pywal as a Python module, let `pywal.export.color()` accept a user defined template file from `~/.config/wal/templates` by filename.